### PR TITLE
Feature/robot wifi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/orwell-int/proxy-robots.svg?branch=master)](https://travis-ci.org/orwell-int/proxy-robots) [![Stories in Ready](https://badge.waffle.io/orwell-int/proxy-robots.png?label=ready&title=Ready)](https://waffle.io/orwell-int/proxy-robots) [![Coverage Status](https://coveralls.io/repos/orwell-int/proxy-robots/badge.svg?branch=master)](https://coveralls.io/r/orwell-int/proxy-robots?branch=master)
+
 proxy-robots
 ============
 
@@ -16,8 +17,6 @@ Get the submodules
 git submodule update --init --recursive
 ```
 
-local setup for coveralls
--------------------------
 Run with maven
 --------------
 Prerequiste: have jdk-7+ installed on your machine
@@ -47,20 +46,17 @@ mvn validate
 mvn clean install
 ```
 
-To update the coveralls status, export your repo token in the following environment variable:
-(You will find it on https://coveralls.io/r/orwell-int/proxy-robots)
-```
-export COVERALLS_REPO_TOKEN=yourToken
-```
-
-To update the coveralls status, export your repo token in the following environment variable:
-(You will find it on https://coveralls.io/r/orwell-int/proxy-robots)
-```
-mvn clean cobertura:cobertura coveralls:report
-```
-
 Run the jar created by the install to start the application
 ```
 java -jar proxy-robots-module/target/proxy-robots-module-0.1.0-jar-with-dependencies.jar -f proxy-robots-module/src/main/resources/configuration.xml
 ```
 
+Local setup for coverage with coveralls
+---------------------------------------
+
+To update the coveralls status, export your repo token in the following environment variable:
+(You will find it on https://coveralls.io/r/orwell-int/proxy-robots)
+```
+export COVERALLS_REPO_TOKEN=yourToken
+mvn clean cobertura:cobertura coveralls:report
+```

--- a/proxy-robots-module/pom.xml
+++ b/proxy-robots-module/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.zeromq</groupId>
             <artifactId>jeromq</artifactId>
-            <version>0.3.4</version>
+            <version>0.3.5</version>
         </dependency>
         <dependency>
             <groupId>lejos.pc</groupId>

--- a/proxy-robots-module/pom.xml
+++ b/proxy-robots-module/pom.xml
@@ -68,17 +68,17 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
+            <version>1.7.21</version>
         </dependency>
         <dependency>
             <groupId>org.zeromq</groupId>

--- a/proxy-robots-module/pom.xml
+++ b/proxy-robots-module/pom.xml
@@ -176,8 +176,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>2.6</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/proxy-robots-module/pom.xml
+++ b/proxy-robots-module/pom.xml
@@ -108,9 +108,8 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
+            <version>1.3.1</version>
         </dependency>
-
     </dependencies>
     <build>
         <plugins>

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
@@ -111,6 +111,18 @@ public class ProxyRobots implements IZmqMessageListener {
         for (final IRobot robot : robotsMap.getNotConnectedRobots()) {
             robot.connect();
         }
+        waitForConnectionAck();
+    }
+
+    private void waitForConnectionAck() {
+        while (!robotsMap.getNotConnectedRobots().isEmpty()) {
+            try {
+                Thread.sleep(THREAD_SLEEP_MS);
+            } catch (InterruptedException e) {
+                logback.error(e.getMessage());
+            }
+        }
+        logback.info("All " + robotsMap.getConnectedRobots().size() + " robot(s) are connected");
     }
 
     protected void sendRegister() {
@@ -193,7 +205,7 @@ public class ProxyRobots implements IZmqMessageListener {
     private void applyInputOnRobot(ZmqMessageBOM input, String routingId) {
         final IRobot targetedRobot = robotsMap.get(routingId);
         final RobotInputSetVisitor inputSetVisitor = new RobotInputSetVisitor(input.getMessageBodyBytes());
-        logback.debug("robotTargeted input : " + inputSetVisitor.inputToString(targetedRobot));
+        logback.debug("robotTargeted input : " + inputSetVisitor.toString(targetedRobot));
         try {
             targetedRobot.accept(inputSetVisitor);
         } catch (MessageNotSentException e) {

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
@@ -9,17 +9,17 @@ import orwell.proxy.config.elements.IConfigRobots;
 import orwell.proxy.config.elements.IConfigServerGame;
 import orwell.proxy.robot.*;
 import orwell.proxy.udp.UdpBeaconFinder;
-import orwell.proxy.zmq.IZmqMessageBroker;
+import orwell.proxy.zmq.GameServerMessageBroker;
+import orwell.proxy.zmq.IGameServerMessageBroker;
 import orwell.proxy.zmq.IZmqMessageListener;
 import orwell.proxy.zmq.ZmqMessageBOM;
-import orwell.proxy.zmq.ZmqMessageBroker;
 
 public class ProxyRobots implements IZmqMessageListener {
     private final static Logger logback = LoggerFactory.getLogger(ProxyRobots.class);
     private static final long THREAD_SLEEP_MS = 10;
     private final IConfigServerGame configServerGame;
     private final IConfigRobots configRobots;
-    private final IZmqMessageBroker messageBroker;
+    private final IGameServerMessageBroker messageBroker;
     private final CommunicationService communicationService = new CommunicationService();
     private final Thread communicationThread = new Thread(communicationService);
     private final long outgoingMessagePeriod;
@@ -27,7 +27,7 @@ public class ProxyRobots implements IZmqMessageListener {
     private int outgoingMessageFiltered;
     private UdpBeaconFinder udpBeaconFinder;
 
-    public ProxyRobots(final IZmqMessageBroker messageBroker,
+    public ProxyRobots(final IGameServerMessageBroker messageBroker,
                        final IConfigFactory configFactory,
                        final IRobotsMap robotsMap) {
         logback.debug("Constructor -- IN");
@@ -47,7 +47,7 @@ public class ProxyRobots implements IZmqMessageListener {
     }
 
     public ProxyRobots(final UdpBeaconFinder udpBeaconFinder,
-                       final ZmqMessageBroker zmqMessageFramework,
+                       final GameServerMessageBroker zmqMessageFramework,
                        final ConfigFactory configFactory,
                        final RobotsMap robotsMap) {
         this(zmqMessageFramework, configFactory, robotsMap);

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
@@ -9,8 +9,8 @@ import orwell.proxy.config.elements.IConfigRobots;
 import orwell.proxy.config.elements.IConfigServerGame;
 import orwell.proxy.robot.*;
 import orwell.proxy.udp.UdpBeaconFinder;
-import orwell.proxy.zmq.GameServerMessageBroker;
-import orwell.proxy.zmq.IGameServerMessageBroker;
+import orwell.proxy.zmq.ServerGameMessageBroker;
+import orwell.proxy.zmq.IServerGameMessageBroker;
 import orwell.proxy.zmq.IZmqMessageListener;
 import orwell.proxy.zmq.ZmqMessageBOM;
 
@@ -19,7 +19,7 @@ public class ProxyRobots implements IZmqMessageListener {
     private static final long THREAD_SLEEP_MS = 10;
     private final IConfigServerGame configServerGame;
     private final IConfigRobots configRobots;
-    private final IGameServerMessageBroker messageBroker;
+    private final IServerGameMessageBroker messageBroker;
     private final CommunicationService communicationService = new CommunicationService();
     private final Thread communicationThread = new Thread(communicationService);
     private final long outgoingMessagePeriod;
@@ -27,7 +27,7 @@ public class ProxyRobots implements IZmqMessageListener {
     private int outgoingMessageFiltered;
     private UdpBeaconFinder udpBeaconFinder;
 
-    public ProxyRobots(final IGameServerMessageBroker messageBroker,
+    public ProxyRobots(final IServerGameMessageBroker messageBroker,
                        final IConfigFactory configFactory,
                        final IRobotsMap robotsMap) {
         logback.debug("Constructor -- IN");
@@ -47,7 +47,7 @@ public class ProxyRobots implements IZmqMessageListener {
     }
 
     public ProxyRobots(final UdpBeaconFinder udpBeaconFinder,
-                       final GameServerMessageBroker zmqMessageFramework,
+                       final ServerGameMessageBroker zmqMessageFramework,
                        final ConfigFactory configFactory,
                        final RobotsMap robotsMap) {
         this(zmqMessageFramework, configFactory, robotsMap);

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
@@ -3,6 +3,7 @@ package orwell.proxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.config.*;
+import orwell.proxy.config.elements.ConfigRobotException;
 import orwell.proxy.config.elements.IConfigRobot;
 import orwell.proxy.config.elements.IConfigRobots;
 import orwell.proxy.config.elements.IConfigServerGame;
@@ -88,7 +89,7 @@ public class ProxyRobots implements IZmqMessageListener {
      * This instantiates Robots objects from a configuration. It only sets up the
      * RobotsMap
      */
-    protected void initializeRobotsFromConfig() {
+    protected void initializeRobotsFromConfig() throws ConfigRobotException {
         for (final IConfigRobot configRobot : configRobots.getConfigRobotsToRegister()) {
             final IRobot robot = RobotFactory.getRobot(configRobot);
             if (null == robot) {
@@ -204,7 +205,7 @@ public class ProxyRobots implements IZmqMessageListener {
      * -start communication service with the server
      * -send register to the server
      */
-    public void start() {
+    public void start() throws ConfigRobotException {
         this.connectToServer();
         if (robotsMap.getRobotsArray().isEmpty())
             this.initializeRobotsFromConfig();

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobots.java
@@ -22,7 +22,6 @@ public class ProxyRobots implements IZmqMessageListener {
     private final CommunicationService communicationService = new CommunicationService();
     private final Thread communicationThread = new Thread(communicationService);
     private final long outgoingMessagePeriod;
-    private final RobotFactory robotFactory;
     protected IRobotsMap robotsMap;
     private int outgoingMessageFiltered;
     private UdpBeaconFinder udpBeaconFinder;
@@ -42,7 +41,6 @@ public class ProxyRobots implements IZmqMessageListener {
         this.robotsMap = robotsMap;
         this.outgoingMessagePeriod = configFactory.getConfigProxy().getOutgoingMsgPeriod();
 
-        robotFactory = new RobotFactory();
         messageBroker.addZmqMessageListener(this);
         logback.debug("Constructor -- OUT");
     }
@@ -92,7 +90,7 @@ public class ProxyRobots implements IZmqMessageListener {
      */
     protected void initializeRobotsFromConfig() {
         for (final IConfigRobot configRobot : configRobots.getConfigRobotsToRegister()) {
-            final IRobot robot = robotFactory.getRobot(configRobot);
+            final IRobot robot = RobotFactory.getRobot(configRobot);
             if (null == robot) {
                 logback.error("Robot not initialized. Skipping it for now.");
             } else {

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobotsFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobotsFactory.java
@@ -8,8 +8,8 @@ import orwell.proxy.robot.RobotsMap;
 import orwell.proxy.udp.UdpBeaconFinder;
 import orwell.proxy.udp.UdpBeaconFinderFactory;
 import orwell.proxy.zmq.FrequencyFilter;
+import orwell.proxy.zmq.GameServerMessageBroker;
 import orwell.proxy.zmq.IFilter;
-import orwell.proxy.zmq.ZmqMessageBroker;
 
 import java.util.ArrayList;
 
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 class ProxyRobotsFactory {
     private final static Logger logback = LoggerFactory.getLogger(ProxyRobotsFactory.class);
     private final ConfigFactory configFactory;
-    private final ZmqMessageBroker zmqMessageBroker;
+    private final GameServerMessageBroker gameServerMessageBroker;
     private final UdpBeaconFinder udpBeaconFinder;
 
     public ProxyRobotsFactory(final Configuration configuration) {
@@ -28,11 +28,11 @@ class ProxyRobotsFactory {
 
         if (null == configFactory.getConfigProxy()) {
             // We do not have the data to initialize the broker and udp discovery
-            zmqMessageBroker = null;
+            gameServerMessageBroker = null;
             udpBeaconFinder = null;
         } else {
 
-            zmqMessageBroker = new ZmqMessageBroker(
+            gameServerMessageBroker = new GameServerMessageBroker(
                     configFactory.getConfigProxy().getReceiveTimeout(),
                     configFactory.getConfigProxy().getSenderLinger(),
                     configFactory.getConfigProxy().getReceiverLinger()
@@ -46,11 +46,11 @@ class ProxyRobotsFactory {
     }
 
     public ProxyRobots getProxyRobots() {
-        if (null == zmqMessageBroker) {
+        if (null == gameServerMessageBroker) {
             return null;
         }
         return new ProxyRobots(
-                udpBeaconFinder, zmqMessageBroker,
+                udpBeaconFinder, gameServerMessageBroker,
                 configFactory, new RobotsMap()
         );
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobotsFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobotsFactory.java
@@ -8,7 +8,7 @@ import orwell.proxy.robot.RobotsMap;
 import orwell.proxy.udp.UdpBeaconFinder;
 import orwell.proxy.udp.UdpBeaconFinderFactory;
 import orwell.proxy.zmq.FrequencyFilter;
-import orwell.proxy.zmq.GameServerMessageBroker;
+import orwell.proxy.zmq.ServerGameMessageBroker;
 import orwell.proxy.zmq.IFilter;
 
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 class ProxyRobotsFactory {
     private final static Logger logback = LoggerFactory.getLogger(ProxyRobotsFactory.class);
     private final ConfigFactory configFactory;
-    private final GameServerMessageBroker gameServerMessageBroker;
+    private final ServerGameMessageBroker serverGameMessageBroker;
     private final UdpBeaconFinder udpBeaconFinder;
 
     public ProxyRobotsFactory(final Configuration configuration) {
@@ -28,11 +28,11 @@ class ProxyRobotsFactory {
 
         if (null == configFactory.getConfigProxy()) {
             // We do not have the data to initialize the broker and udp discovery
-            gameServerMessageBroker = null;
+            serverGameMessageBroker = null;
             udpBeaconFinder = null;
         } else {
 
-            gameServerMessageBroker = new GameServerMessageBroker(
+            serverGameMessageBroker = new ServerGameMessageBroker(
                     configFactory.getConfigProxy().getReceiveTimeout(),
                     configFactory.getConfigProxy().getSenderLinger(),
                     configFactory.getConfigProxy().getReceiverLinger()
@@ -46,11 +46,11 @@ class ProxyRobotsFactory {
     }
 
     public ProxyRobots getProxyRobots() {
-        if (null == gameServerMessageBroker) {
+        if (null == serverGameMessageBroker) {
             return null;
         }
         return new ProxyRobots(
-                udpBeaconFinder, gameServerMessageBroker,
+                udpBeaconFinder, serverGameMessageBroker,
                 configFactory, new RobotsMap()
         );
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobotsFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/ProxyRobotsFactory.java
@@ -8,15 +8,15 @@ import orwell.proxy.robot.RobotsMap;
 import orwell.proxy.udp.UdpBeaconFinder;
 import orwell.proxy.udp.UdpBeaconFinderFactory;
 import orwell.proxy.zmq.FrequencyFilter;
-import orwell.proxy.zmq.ServerGameMessageBroker;
 import orwell.proxy.zmq.IFilter;
+import orwell.proxy.zmq.ServerGameMessageBroker;
 
 import java.util.ArrayList;
 
 /**
  * Created by Michaël Ludmann on 03/05/15.
  */
-class ProxyRobotsFactory {
+public class ProxyRobotsFactory {
     private final static Logger logback = LoggerFactory.getLogger(ProxyRobotsFactory.class);
     private final ConfigFactory configFactory;
     private final ServerGameMessageBroker serverGameMessageBroker;

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigMessaging.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigMessaging.java
@@ -1,0 +1,7 @@
+package orwell.proxy.config.elements;
+
+/**
+ * Created by Michaël Ludmann on 27/06/16.
+ */
+public class ConfigMessaging {
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigMessaging.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigMessaging.java
@@ -1,7 +1,29 @@
 package orwell.proxy.config.elements;
 
+import javax.xml.bind.annotation.XmlElement;
+
 /**
  * Created by Michaël Ludmann on 27/06/16.
  */
 public class ConfigMessaging {
+    private int pushPort;
+    private int pullPort;
+
+    public int getPushPort() {
+        return pushPort;
+    }
+
+    @XmlElement
+    public void setPushPort(int pushPort) {
+        this.pushPort = pushPort;
+    }
+
+    public int getPullPort() {
+        return pullPort;
+    }
+
+    @XmlElement
+    public void setPullPort(int pullPort) {
+        this.pullPort = pullPort;
+    }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigNetworkInterface.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigNetworkInterface.java
@@ -1,0 +1,49 @@
+package orwell.proxy.config.elements;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * Created by Michaël Ludmann on 23/06/16.
+ */
+@XmlType(propOrder = {"macAddress", "ipAddress"})
+public class ConfigNetworkInterface implements IConfigNetworkInterface {
+
+    private String macAddress;
+    private String ipAddress;
+    private String networkAddress;
+
+    @Override
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    @Override
+    @XmlElement(name = "mac")
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
+    @Override
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    @Override
+    @XmlElement(name = "ip")
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    @Override
+    @XmlAttribute(name = "addr")
+    public String getNetworkAddress() {
+        return networkAddress;
+    }
+
+    @Override
+    public void setNetworkAddress(String networkAddress) {
+        this.networkAddress = networkAddress;
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigRobotException.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigRobotException.java
@@ -1,0 +1,19 @@
+package orwell.proxy.config.elements;
+
+/**
+ * Created by Michaël Ludmann on 26/06/16.
+ */
+public class ConfigRobotException extends Exception {
+    final private IConfigRobot configRobot;
+    final private String missingField;
+
+    public ConfigRobotException(ConfigTank configTank, String missingField) {
+        configRobot = configTank;
+        this.missingField = missingField;
+    }
+
+    public String getMessage() {
+        return "[Configuration File] " + configRobot.getClass() +
+                " is missing mandatory field: " + missingField;
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigScout.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigScout.java
@@ -1,16 +1,17 @@
 package orwell.proxy.config.elements;
 
+import orwell.proxy.robot.EnumModel;
+
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
 
-@XmlType(propOrder = {"camera", "image"})
 public class ConfigScout implements IConfigRobot {
 
     private String tempRoutingID;
     private ConfigCamera camera;
     private boolean shouldRegister;
     private String image;
+    private String model;
 
     @Override
     public String getTempRoutingID() {
@@ -52,5 +53,26 @@ public class ConfigScout implements IConfigRobot {
     @XmlElement
     public void setImage(final String image) {
         this.image = image;
+    }
+
+    @Override
+    public IConfigNetworkInterface getConfigNetworkInterface(String address) {
+        return null;
+    }
+
+    @Override
+    public String getModel() {
+        return model;
+    }
+
+    @Override
+    @XmlAttribute
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    @Override
+    public EnumModel getEnumModel() {
+        return EnumModel.getModelFromString(model);
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigScout.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigScout.java
@@ -12,6 +12,7 @@ public class ConfigScout implements IConfigRobot {
     private boolean shouldRegister;
     private String image;
     private String model;
+    private String hostname;
 
     @Override
     public String getTempRoutingID() {
@@ -74,5 +75,16 @@ public class ConfigScout implements IConfigRobot {
     @Override
     public EnumModel getEnumModel() {
         return EnumModel.getModelFromString(model);
+    }
+
+    @Override
+    public String getHostname() {
+        return hostname;
+    }
+
+    @Override
+    @XmlElement
+    public void setHostname(final String hostname) {
+        this.hostname = hostname;
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigScout.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigScout.java
@@ -13,6 +13,7 @@ public class ConfigScout implements IConfigRobot {
     private String image;
     private String model;
     private String hostname;
+    private ConfigMessaging configMessaging;
 
     @Override
     public String getTempRoutingID() {
@@ -86,5 +87,16 @@ public class ConfigScout implements IConfigRobot {
     @XmlElement
     public void setHostname(final String hostname) {
         this.hostname = hostname;
+    }
+
+    @Override
+    public ConfigMessaging getConfigMessaging() {
+        return configMessaging;
+    }
+
+    @Override
+    @XmlElement
+    public void setConfigMessaging(ConfigMessaging configMessaging) {
+        this.configMessaging = configMessaging;
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigTank.java
@@ -1,18 +1,20 @@
 package orwell.proxy.config.elements;
 
+import orwell.proxy.robot.EnumModel;
+
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import java.util.List;
 
-@XmlType(propOrder = {"bluetoothName", "bluetoothID", "camera", "image"})
 public class ConfigTank implements IConfigRobot {
-
     private String tempRoutingID;
     private String bluetoothName;
     private String bluetoothID;
     private ConfigCamera camera;
     private boolean shouldRegister;
     private String image;
+    private List<ConfigNetworkInterface> configNetworkInterfaces;
+    private String model;
 
     @Override
     public String getTempRoutingID() {
@@ -34,6 +36,22 @@ public class ConfigTank implements IConfigRobot {
     @XmlAttribute
     public void setShouldRegister(final boolean shouldRegister) {
         this.shouldRegister = shouldRegister;
+    }
+
+    @Override
+    public String getModel() {
+        return model;
+    }
+
+    @Override
+    @XmlAttribute
+    public void setModel(final String model) {
+        this.model = model;
+    }
+
+    @Override
+    public EnumModel getEnumModel() {
+        return EnumModel.getModelFromString(model);
     }
 
     public String getBluetoothName() {
@@ -72,5 +90,23 @@ public class ConfigTank implements IConfigRobot {
     @XmlElement
     public void setImage(final String image) {
         this.image = image;
+    }
+
+    @XmlElement(name = "networkInterface")
+    public List<ConfigNetworkInterface> getConfigNetworkInterfaces() {
+        return configNetworkInterfaces;
+    }
+
+    public void setConfigNetworkInterfaces(final List<ConfigNetworkInterface> configNetworkInterfaces) {
+        this.configNetworkInterfaces = configNetworkInterfaces;
+    }
+
+    @Override
+    public ConfigNetworkInterface getConfigNetworkInterface(String networkAddress) throws ConfigRobotException {
+        for (final ConfigNetworkInterface config : this.configNetworkInterfaces) {
+            if (config.getNetworkAddress().contentEquals(networkAddress))
+                return config;
+        }
+        throw new ConfigRobotException(this, networkAddress);
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigTank.java
@@ -15,6 +15,7 @@ public class ConfigTank implements IConfigRobot {
     private String image;
     private List<ConfigNetworkInterface> configNetworkInterfaces;
     private String model;
+    private String hostname;
 
     @Override
     public String getTempRoutingID() {
@@ -102,11 +103,22 @@ public class ConfigTank implements IConfigRobot {
     }
 
     @Override
-    public ConfigNetworkInterface getConfigNetworkInterface(String networkAddress) throws ConfigRobotException {
+    public ConfigNetworkInterface getConfigNetworkInterface(final String networkAddress) throws ConfigRobotException {
         for (final ConfigNetworkInterface config : this.configNetworkInterfaces) {
             if (config.getNetworkAddress().contentEquals(networkAddress))
                 return config;
         }
         throw new ConfigRobotException(this, networkAddress);
+    }
+
+    @Override
+    public String getHostname() {
+        return hostname;
+    }
+
+    @Override
+    @XmlElement
+    public void setHostname(final String hostname) {
+        this.hostname = hostname;
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/ConfigTank.java
@@ -16,6 +16,7 @@ public class ConfigTank implements IConfigRobot {
     private List<ConfigNetworkInterface> configNetworkInterfaces;
     private String model;
     private String hostname;
+    private ConfigMessaging configMessaging;
 
     @Override
     public String getTempRoutingID() {
@@ -77,8 +78,8 @@ public class ConfigTank implements IConfigRobot {
         return camera;
     }
 
-    @XmlElement
-    public void setCamera(final ConfigCamera camera) {
+    @XmlElement(name = "camera")
+    public void setConfigCamera(final ConfigCamera camera) {
         this.camera = camera;
     }
 
@@ -121,4 +122,15 @@ public class ConfigTank implements IConfigRobot {
     public void setHostname(final String hostname) {
         this.hostname = hostname;
     }
+
+    @XmlElement(name = "messaging")
+    public ConfigMessaging getConfigMessaging() {
+        return configMessaging;
+    }
+
+    @Override
+    public void setConfigMessaging(final ConfigMessaging configMessaging) {
+        this.configMessaging = configMessaging;
+    }
+
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigNetworkInterface.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigNetworkInterface.java
@@ -1,0 +1,19 @@
+package orwell.proxy.config.elements;
+
+/**
+ * Created by Michaël Ludmann on 23/06/16.
+ */
+public interface IConfigNetworkInterface {
+
+    public String getMacAddress();
+
+    public void setMacAddress(final String macAddress);
+
+    public String getIpAddress();
+
+    public void setIpAddress(final String ipAddress);
+
+    public String getNetworkAddress();
+
+    public void setNetworkAddress(final String networkAddress);
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigRobot.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigRobot.java
@@ -1,5 +1,7 @@
 package orwell.proxy.config.elements;
 
+import orwell.proxy.robot.EnumModel;
+
 /**
  * Created by Michaël Ludmann on 5/22/15.
  */
@@ -16,4 +18,12 @@ public interface IConfigRobot {
     public String getImage();
 
     public void setImage(final String image);
+
+    public IConfigNetworkInterface getConfigNetworkInterface(String address) throws ConfigRobotException;
+
+    public String getModel();
+
+    EnumModel getEnumModel();
+
+    public void setModel(final String model);
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigRobot.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigRobot.java
@@ -2,35 +2,36 @@ package orwell.proxy.config.elements;
 
 import orwell.proxy.robot.EnumModel;
 
-import javax.xml.bind.annotation.XmlElement;
-
 /**
  * Created by Michaël Ludmann on 5/22/15.
  */
 public interface IConfigRobot {
 
-    public String getTempRoutingID();
+    String getTempRoutingID();
 
-    public void setTempRoutingID(final String tempRoutingID);
+    void setTempRoutingID(final String tempRoutingID);
 
-    public boolean shouldRegister();
+    boolean shouldRegister();
 
-    public void setShouldRegister(final boolean shouldRegister);
+    void setShouldRegister(final boolean shouldRegister);
 
-    public String getImage();
+    String getImage();
 
-    public void setImage(final String image);
+    void setImage(final String image);
 
-    public IConfigNetworkInterface getConfigNetworkInterface(String address) throws ConfigRobotException;
+    IConfigNetworkInterface getConfigNetworkInterface(String address) throws ConfigRobotException;
 
-    public String getModel();
+    String getModel();
 
-    public void setModel(final String model);
+    void setModel(final String model);
 
     EnumModel getEnumModel();
 
     String getHostname();
 
-    @XmlElement
     void setHostname(String hostname);
+
+    ConfigMessaging getConfigMessaging();
+
+    void setConfigMessaging(ConfigMessaging configMessaging);
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigRobot.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/config/elements/IConfigRobot.java
@@ -2,6 +2,8 @@ package orwell.proxy.config.elements;
 
 import orwell.proxy.robot.EnumModel;
 
+import javax.xml.bind.annotation.XmlElement;
+
 /**
  * Created by Michaël Ludmann on 5/22/15.
  */
@@ -23,7 +25,12 @@ public interface IConfigRobot {
 
     public String getModel();
 
+    public void setModel(final String model);
+
     EnumModel getEnumModel();
 
-    public void setModel(final String model);
+    String getHostname();
+
+    @XmlElement
+    void setHostname(String hostname);
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
@@ -23,7 +23,7 @@ public class DirectController {
 
     public DirectController(final IRobot robot) {
         this.robot = robot;
-        this.gameGUI = new GameGUI(robot);
+        gameGUI = new GameGUI(robot);
     }
 
     public static void main(final String[] args) throws Exception {

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
@@ -8,7 +8,7 @@ import orwell.proxy.config.Configuration;
 import orwell.proxy.config.elements.ConfigRobots;
 import orwell.proxy.config.elements.IConfigRobot;
 import orwell.proxy.robot.IRobot;
-import orwell.proxy.robot.LegoTank;
+import orwell.proxy.robot.LegoNxtTank;
 import orwell.proxy.robot.RobotFactory;
 
 import java.util.ArrayList;
@@ -37,8 +37,8 @@ public class DirectController {
         final ConfigRobots configRobots = configModel.getConfigRobots();
         final ArrayList<IConfigRobot> robots = configRobots.getConfigRobotsToRegister();
 
-        final LegoTank legoTank = (LegoTank) RobotFactory.getRobot(robots.get(0));
-        final DirectController controller = new DirectController(legoTank);
+        final LegoNxtTank legoNxtTank = (LegoNxtTank) RobotFactory.getRobot(robots.get(0));
+        final DirectController controller = new DirectController(legoNxtTank);
         controller.start();
     }
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
@@ -8,7 +8,7 @@ import orwell.proxy.config.Configuration;
 import orwell.proxy.config.elements.ConfigRobots;
 import orwell.proxy.config.elements.IConfigRobot;
 import orwell.proxy.robot.IRobot;
-import orwell.proxy.robot.LegoNxtTank;
+import orwell.proxy.robot.LegoEv3Tank;
 import orwell.proxy.robot.RobotFactory;
 
 import java.util.ArrayList;
@@ -23,10 +23,12 @@ public class DirectController {
 
     public DirectController(final IRobot robot) {
         this.robot = robot;
-        this.gameGUI = new GameGUI();
+        this.gameGUI = new GameGUI(robot);
     }
 
     public static void main(final String[] args) throws Exception {
+
+
         final Configuration configuration = new Cli(args).parse();
         if (null == configuration) {
             logback.warn("Command Line Interface did not manage to extract a configuration. Exiting now.");
@@ -37,8 +39,8 @@ public class DirectController {
         final ConfigRobots configRobots = configModel.getConfigRobots();
         final ArrayList<IConfigRobot> robots = configRobots.getConfigRobotsToRegister();
 
-        final LegoNxtTank legoNxtTank = (LegoNxtTank) RobotFactory.getRobot(robots.get(0));
-        final DirectController controller = new DirectController(legoNxtTank);
+        final LegoEv3Tank legoEv3Tank = (LegoEv3Tank) RobotFactory.getRobot(robots.get(0));
+        final DirectController controller = new DirectController(legoEv3Tank);
         controller.start();
     }
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/DirectController.java
@@ -1,0 +1,48 @@
+package orwell.proxy.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import orwell.proxy.Cli;
+import orwell.proxy.config.ConfigModel;
+import orwell.proxy.config.Configuration;
+import orwell.proxy.config.elements.ConfigRobots;
+import orwell.proxy.config.elements.IConfigRobot;
+import orwell.proxy.robot.IRobot;
+import orwell.proxy.robot.LegoTank;
+import orwell.proxy.robot.RobotFactory;
+
+import java.util.ArrayList;
+
+/**
+ * Created by Michaël Ludmann on 6/18/15.
+ */
+public class DirectController {
+    private final static Logger logback = LoggerFactory.getLogger(DirectController.class);
+    private final IRobot robot;
+    private final GameGUI gameGUI;
+
+    public DirectController(final IRobot robot) {
+        this.robot = robot;
+        this.gameGUI = new GameGUI();
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Configuration configuration = new Cli(args).parse();
+        if (null == configuration) {
+            logback.warn("Command Line Interface did not manage to extract a configuration. Exiting now.");
+            System.exit(0);
+        }
+
+        final ConfigModel configModel = configuration.getConfigModel();
+        final ConfigRobots configRobots = configModel.getConfigRobots();
+        final ArrayList<IConfigRobot> robots = configRobots.getConfigRobotsToRegister();
+
+        final LegoTank legoTank = (LegoTank) RobotFactory.getRobot(robots.get(0));
+        final DirectController controller = new DirectController(legoTank);
+        controller.start();
+    }
+
+    private void start() {
+
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
@@ -1,0 +1,37 @@
+package orwell.proxy.controller;
+
+import javax.swing.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+
+/**
+ * Created by Michaël Ludmann on 6/18/15.
+ */
+public class GameGUI extends JFrame {
+    private static final String TITLE = "Direct control";
+    private static final int GUI_WIDTH = 200;
+    private static final int GUI_HEIGHT = 200;
+
+    public GameGUI() {
+        this.run();
+    }
+
+    private void run() {
+        //Setting frame
+        this.setTitle(TITLE);
+        this.setSize(GUI_WIDTH, GUI_HEIGHT);
+        this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        this.setResizable(true);
+
+        final WindowListener listener = new WindowAdapter() {
+            public void windowClosing(WindowEvent w) {
+                //m_imageStreamComponent.Kill();
+            }
+        };
+
+        this.addWindowListener(listener);
+        //m_frame.pack();
+        this.setVisible(true);
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
@@ -1,19 +1,29 @@
 package orwell.proxy.controller;
 
+import lejos.mf.common.SimpleUnitMessage;
+import lejos.mf.common.UnitMessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import orwell.proxy.robot.IRobot;
+import orwell.proxy.robot.MessageNotSentException;
+
 import javax.swing.*;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-import java.awt.event.WindowListener;
+import java.awt.event.*;
 
 /**
  * Created by Michaël Ludmann on 6/18/15.
  */
-public class GameGUI extends JFrame {
+public class GameGUI extends JFrame implements KeyListener {
+    private final static Logger logback = LoggerFactory.getLogger(GameGUI.class);
+
     private static final String TITLE = "Direct control";
     private static final int GUI_WIDTH = 200;
     private static final int GUI_HEIGHT = 200;
+    private final IRobot robot;
 
-    public GameGUI() {
+    public GameGUI(IRobot robot) {
+        this.robot = robot;
+        robot.connect();
         this.run();
     }
 
@@ -26,12 +36,44 @@ public class GameGUI extends JFrame {
 
         final WindowListener listener = new WindowAdapter() {
             public void windowClosing(WindowEvent w) {
-                //m_imageStreamComponent.Kill();
+                logback.info("Ending Direct controller");
+                robot.closeConnection();
+                System.exit(0);
             }
         };
 
         this.addWindowListener(listener);
-        //m_frame.pack();
+        this.addKeyListener(this);
         this.setVisible(true);
+    }
+
+    @Override
+    public void keyTyped(KeyEvent e) {
+
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
+        logback.debug("Key released: " + e.getKeyChar());
+
+        if (e.getKeyCode() == 83) {
+            logback.debug("Close connection");
+            robot.closeConnection();
+            System.exit(0);
+        }
+
+        SimpleUnitMessage unitMessage = new SimpleUnitMessage();
+        unitMessage.setMessageType(UnitMessageType.Command);
+        unitMessage.setPayload("move 0.50 0.50");
+        try {
+            robot.sendUnitMessage(unitMessage);
+        } catch (MessageNotSentException ex) {
+            logback.error(ex.getMessage());
+        }
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
@@ -61,7 +61,7 @@ public class GameGUI extends JFrame implements KeyListener {
     public void keyReleased(KeyEvent e) {
         logback.debug("Key released: " + e.getKeyChar());
 
-        if (e.getKeyCode() == 83) {
+        if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
             logback.debug("Close connection");
             robot.closeConnection();
             System.exit(0);

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
@@ -36,9 +36,7 @@ public class GameGUI extends JFrame implements KeyListener {
 
         final WindowListener listener = new WindowAdapter() {
             public void windowClosing(WindowEvent w) {
-                logback.info("Ending Direct controller");
-                robot.closeConnection();
-                System.exit(0);
+                closeConnectionAndExit();
             }
         };
 
@@ -62,9 +60,7 @@ public class GameGUI extends JFrame implements KeyListener {
         logback.debug("Key released: " + e.getKeyChar());
 
         if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
-            logback.debug("Close connection");
-            robot.closeConnection();
-            System.exit(0);
+            closeConnectionAndExit();
         }
 
         UnitMessage unitMessage = new UnitMessage(UnitMessageType.Command, "move 0.50 0.50");
@@ -74,5 +70,11 @@ public class GameGUI extends JFrame implements KeyListener {
         } catch (MessageNotSentException ex) {
             logback.error(ex.getMessage());
         }
+    }
+
+    private void closeConnectionAndExit() {
+        logback.debug("Close connection");
+        robot.closeConnection();
+        System.exit(0);
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
@@ -31,7 +31,7 @@ public class GameGUI extends JFrame implements KeyListener {
         //Setting frame
         this.setTitle(TITLE);
         this.setSize(GUI_WIDTH, GUI_HEIGHT);
-        this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        this.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         this.setResizable(true);
 
         final WindowListener listener = new WindowAdapter() {
@@ -59,14 +59,32 @@ public class GameGUI extends JFrame implements KeyListener {
     public void keyReleased(KeyEvent e) {
         logback.debug("Key released: " + e.getKeyChar());
 
-        if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
-            closeConnectionAndExit();
+
+        UnitMessage unitMessage;
+        if (e.getKeyCode() == KeyEvent.VK_UP) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "move 0.50 0.50");
+        } else if (e.getKeyCode() == KeyEvent.VK_DOWN) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "move -0.50 -0.50");
+        } else if (e.getKeyCode() == KeyEvent.VK_LEFT) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "move -0.50 0.50");
+        } else if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "move 0.50 -0.50");
+        } else if (e.getKeyCode() == KeyEvent.VK_NUMPAD1) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "fire true false");
+        } else if (e.getKeyCode() == KeyEvent.VK_NUMPAD2) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "fire false true");
+        } else if (e.getKeyCode() == KeyEvent.VK_SPACE) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "stop");
+        } else if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "stopPrg");
+        } else {
+            unitMessage = new UnitMessage(UnitMessageType.Command, "game nini");
         }
-
-        UnitMessage unitMessage = new UnitMessage(UnitMessageType.Command, "move 0.50 0.50");
-
         try {
             robot.sendUnitMessage(unitMessage);
+            if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+                closeConnectionAndExit();
+            }
         } catch (MessageNotSentException ex) {
             logback.error(ex.getMessage());
         }

--- a/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/controller/GameGUI.java
@@ -1,6 +1,6 @@
 package orwell.proxy.controller;
 
-import lejos.mf.common.SimpleUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.UnitMessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,9 +67,8 @@ public class GameGUI extends JFrame implements KeyListener {
             System.exit(0);
         }
 
-        SimpleUnitMessage unitMessage = new SimpleUnitMessage();
-        unitMessage.setMessageType(UnitMessageType.Command);
-        unitMessage.setPayload("move 0.50 0.50");
+        UnitMessage unitMessage = new UnitMessage(UnitMessageType.Command, "move 0.50 0.50");
+
         try {
             robot.sendUnitMessage(unitMessage);
         } catch (MessageNotSentException ex) {

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/EnumModel.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/EnumModel.java
@@ -1,0 +1,22 @@
+package orwell.proxy.robot;
+
+/**
+ * Created by Michaël Ludmann on 26/06/16.
+ */
+public enum EnumModel {
+    EV3,
+    NXT;
+
+    public static EnumModel getModelFromString(String model) {
+        if (model == null)
+        {
+            return EnumModel.NXT;
+        }
+        switch (model.toLowerCase()){
+            case "ev3":
+                return EV3;
+            default:
+                return NXT;
+        }
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.IUnitMessage;
 
 import java.util.UUID;
 
@@ -17,7 +17,7 @@ public abstract class IRobot implements IRobotElement, IRobotInput {
     private EnumConnectionState connectionState = EnumConnectionState.NOT_CONNECTED;
     private EnumRobotVictoryState victoryState = EnumRobotVictoryState.WAITING_FOR_START;
 
-    public abstract void sendUnitMessage(UnitMessage unitMessage);
+    public abstract void sendUnitMessage(IUnitMessage unitMessage);
 
     public abstract EnumConnectionState connect();
 
@@ -79,4 +79,8 @@ public abstract class IRobot implements IRobotElement, IRobotInput {
     protected void setVictoryState(final EnumRobotVictoryState victoryState) {
         this.victoryState = victoryState;
     }
+
+    public abstract void setRfidValue(String rfidValue);
+
+    public abstract void setColourValue(String colourValue);
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
@@ -1,6 +1,8 @@
 package orwell.proxy.robot;
 
 import lejos.mf.common.UnitMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
@@ -8,6 +10,7 @@ import java.util.UUID;
  * Created by Michaël Ludmann on 5/18/15.
  */
 public abstract class IRobot implements IRobotElement, IRobotInput {
+    private final static Logger logback = LoggerFactory.getLogger(IRobot.class);
 
     private String routingId = UUID.randomUUID().toString();
     private String cameraUrl;
@@ -70,6 +73,7 @@ public abstract class IRobot implements IRobotElement, IRobotInput {
 
     protected void setConnectionState(final EnumConnectionState connectionState) {
         this.connectionState = connectionState;
+        logback.info("Robot [" + routingId + "] changed its connection status to " + connectionState);
     }
 
     public EnumRobotVictoryState getVictoryState() {

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
@@ -17,7 +17,7 @@ public abstract class IRobot implements IRobotElement, IRobotInput {
     private EnumConnectionState connectionState = EnumConnectionState.NOT_CONNECTED;
     private EnumRobotVictoryState victoryState = EnumRobotVictoryState.WAITING_FOR_START;
 
-    public abstract void sendUnitMessage(IUnitMessage unitMessage);
+    public abstract void sendUnitMessage(IUnitMessage unitMessage) throws MessageNotSentException;
 
     public abstract EnumConnectionState connect();
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobot.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.IUnitMessage;
+import lejos.mf.common.UnitMessage;
 
 import java.util.UUID;
 
@@ -17,7 +17,7 @@ public abstract class IRobot implements IRobotElement, IRobotInput {
     private EnumConnectionState connectionState = EnumConnectionState.NOT_CONNECTED;
     private EnumRobotVictoryState victoryState = EnumRobotVictoryState.WAITING_FOR_START;
 
-    public abstract void sendUnitMessage(IUnitMessage unitMessage) throws MessageNotSentException;
+    public abstract void sendUnitMessage(UnitMessage unitMessage) throws MessageNotSentException;
 
     public abstract EnumConnectionState connect();
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobotInput.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobotInput.java
@@ -4,5 +4,5 @@ package orwell.proxy.robot;
  * Created by Michaël Ludmann on 5/18/15.
  */
 public interface IRobotInput {
-    void accept(final IRobotInputVisitor visitor);
+    void accept(final IRobotInputVisitor visitor) throws MessageNotSentException;
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobotInputVisitor.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobotInputVisitor.java
@@ -8,5 +8,5 @@ public interface IRobotInputVisitor {
 
     void visit(final InputFire inputFire);
 
-    void visit(final IRobot robot);
+    void visit(final IRobot robot) throws MessageNotSentException;
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobotsMap.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/IRobotsMap.java
@@ -37,5 +37,5 @@ public interface IRobotsMap {
 
     boolean isRobotRegistered(String routingId);
 
-    void accept(RobotGameStateVisitor robotGameStateVisitor);
+    void accept(RobotGameStateVisitor robotGameStateVisitor) throws Exception;
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.StreamUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.UnitMessageType;
 import orwell.messages.Controller;
 
@@ -31,8 +31,9 @@ public class InputFire implements IRobotInput {
         // "input fire fireWeapon1 fireWeapon2"
         if (fire.getWeapon1() || fire.getWeapon2()) // We avoid flooding the robot if there is no fire
             try {
+                // TODO change sendUnitMessage signature to delay implementation choice of unitMessage to IRobot
                 robot.sendUnitMessage(
-                        new StreamUnitMessage(
+                        new UnitMessage(
                                 UnitMessageType.Command, FIRE_PAYLOAD_HEADER +
                                 fire.getWeapon1() + " " + fire.getWeapon2())
                 );

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
@@ -2,12 +2,16 @@ package orwell.proxy.robot;
 
 import lejos.mf.common.UnitMessage;
 import lejos.mf.common.UnitMessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import orwell.messages.Controller;
 
 /**
  * Created by Michaël Ludmann on 5/18/15.
  */
 public class InputFire implements IRobotInput {
+    final static Logger logback = LoggerFactory.getLogger(IRobotInput.class);
+
 
     private final static String FIRE_PAYLOAD_HEADER = "fire ";
     private Controller.Input.Fire fire;
@@ -31,14 +35,13 @@ public class InputFire implements IRobotInput {
         // "input fire fireWeapon1 fireWeapon2"
         if (fire.getWeapon1() || fire.getWeapon2()) // We avoid flooding the robot if there is no fire
             try {
-                // TODO change sendUnitMessage signature to delay implementation choice of unitMessage to IRobot
                 robot.sendUnitMessage(
                         new UnitMessage(
                                 UnitMessageType.Command, FIRE_PAYLOAD_HEADER +
                                 fire.getWeapon1() + " " + fire.getWeapon2())
                 );
             } catch (MessageNotSentException e) {
-                e.printStackTrace();
+                logback.error(e.getMessage());
             }
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
@@ -30,10 +30,14 @@ public class InputFire implements IRobotInput {
     public void sendUnitMessageTo(final IRobot robot) {
         // "input fire fireWeapon1 fireWeapon2"
         if (fire.getWeapon1() || fire.getWeapon2()) // We avoid flooding the robot if there is no fire
-            robot.sendUnitMessage(
-                    new StreamUnitMessage(
-                            UnitMessageType.Command, FIRE_PAYLOAD_HEADER +
-                            fire.getWeapon1() + " " + fire.getWeapon2())
-            );
+            try {
+                robot.sendUnitMessage(
+                        new StreamUnitMessage(
+                                UnitMessageType.Command, FIRE_PAYLOAD_HEADER +
+                                fire.getWeapon1() + " " + fire.getWeapon2())
+                );
+            } catch (MessageNotSentException e) {
+                e.printStackTrace();
+            }
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/InputFire.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.common.UnitMessageType;
 import orwell.messages.Controller;
 
@@ -31,7 +31,7 @@ public class InputFire implements IRobotInput {
         // "input fire fireWeapon1 fireWeapon2"
         if (fire.getWeapon1() || fire.getWeapon2()) // We avoid flooding the robot if there is no fire
             robot.sendUnitMessage(
-                    new UnitMessage(
+                    new StreamUnitMessage(
                             UnitMessageType.Command, FIRE_PAYLOAD_HEADER +
                             fire.getWeapon1() + " " + fire.getWeapon2())
             );

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/InputMove.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/InputMove.java
@@ -30,7 +30,7 @@ public class InputMove implements IRobotInput {
         visitor.visit(this);
     }
 
-    public void sendUnitMessageTo(final IRobot robot) {
+    public void sendUnitMessageTo(final IRobot robot) throws MessageNotSentException {
         // "input move leftMove rightMove"
         robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, MOVE_PAYLOAD_HEADER + move.getLeft() + " " + move.getRight()));
     }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/InputMove.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/InputMove.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.StreamUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.UnitMessageType;
 import orwell.messages.Controller.Input;
 
@@ -32,6 +32,9 @@ public class InputMove implements IRobotInput {
 
     public void sendUnitMessageTo(final IRobot robot) throws MessageNotSentException {
         // "input move leftMove rightMove"
-        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, MOVE_PAYLOAD_HEADER + move.getLeft() + " " + move.getRight()));
+
+        // TODO change sendUnitMessage signature to delay implementation choice of unitMessage to IRobot
+        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, MOVE_PAYLOAD_HEADER + move.getLeft() + " " + move.getRight()) {
+        });
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/InputMove.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/InputMove.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.common.UnitMessageType;
 import orwell.messages.Controller.Input;
 
@@ -32,6 +32,6 @@ public class InputMove implements IRobotInput {
 
     public void sendUnitMessageTo(final IRobot robot) {
         // "input move leftMove rightMove"
-        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, MOVE_PAYLOAD_HEADER + move.getLeft() + " " + move.getRight()));
+        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, MOVE_PAYLOAD_HEADER + move.getLeft() + " " + move.getRight()));
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -1,9 +1,7 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.IUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.MessageListenerInterface;
-import lejos.mf.common.SimpleUnitMessage;
-import lejos.mf.common.StreamUnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.zmq.RobotMessageBroker;
@@ -43,15 +41,15 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
 
 
     @Override
-    public void sendUnitMessage(final IUnitMessage unitMessage) throws MessageNotSentException {
+    public void sendUnitMessage(final UnitMessage unitMessage) throws MessageNotSentException {
         if (!sendMessageSucceeds(unitMessage)) {
             logback.error("Unable to send message to robot " + this.hostname + ". ABORT!");
             throw new MessageNotSentException(hostname);
         }
     }
 
-    private boolean sendMessageSucceeds(IUnitMessage unitMessage) {
-        return robotMessageBroker.send((SimpleUnitMessage) unitMessage);
+    private boolean sendMessageSucceeds(UnitMessage unitMessage) {
+        return robotMessageBroker.send(unitMessage);
     }
 
     @Override
@@ -71,17 +69,18 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
 
     @Override
     public void accept(IRobotElementVisitor visitor) {
-
+        for (final IRobotElement element : robotElements) {
+            element.accept(visitor);
+        }
+        visitor.visit(this);
     }
 
     @Override
-    public void accept(IRobotInputVisitor visitor) {
-
-    }
-
-    @Override
-    public void receivedNewMessage(StreamUnitMessage msg) {
-
+    public void accept(IRobotInputVisitor visitor) throws MessageNotSentException {
+        for (final IRobotInput action : robotActions) {
+            action.accept(visitor);
+        }
+        visitor.visit(this);
     }
 
     @Override
@@ -89,5 +88,10 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
         return "LegoEv3Tank { [Hostname] " + hostname + " [IP] " +
                 ipAddress + " [RoutingID] " + getRoutingId() +
                 " [TeamName] " + getTeamName() + " }";
+    }
+
+    @Override
+    public void receivedNewMessage(UnitMessage msg) {
+        // TODO implement this part
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -28,6 +28,7 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
         this.hostname = hostname;
         this.ipAddress = ipAddress;
         robotMessageBroker = new RobotMessageBroker(pushPort, pullPort);
+        setCameraUrl("nc:" + ipAddress + ":" + videoStreamPort);
     }
 
     @Override
@@ -42,8 +43,15 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
 
 
     @Override
-    public void sendUnitMessage(final IUnitMessage unitMessage) {
-        robotMessageBroker.send((SimpleUnitMessage) unitMessage);
+    public void sendUnitMessage(final IUnitMessage unitMessage) throws MessageNotSentException {
+        if (!sendMessageSucceeds(unitMessage)) {
+            logback.error("Unable to send message to robot " + this.hostname + ". ABORT!");
+            throw new MessageNotSentException(hostname);
+        }
+    }
+
+    private boolean sendMessageSucceeds(IUnitMessage unitMessage) {
+        return robotMessageBroker.send((SimpleUnitMessage) unitMessage);
     }
 
     @Override
@@ -58,6 +66,7 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
         if (EnumConnectionState.CONNECTED == getConnectionState()) {
             robotMessageBroker.close();
         }
+        setConnectionState(EnumConnectionState.NOT_CONNECTED);
     }
 
     @Override

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -1,7 +1,7 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
 import lejos.mf.common.MessageListenerInterface;
+import lejos.mf.common.UnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.zmq.RobotMessageBroker;
@@ -27,12 +27,13 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
         this.hostname = hostname;
         this.ipAddress = ipAddress;
         robotMessageBroker = new RobotMessageBroker(pushPort, pullPort);
+        robotMessageBroker.addMessageListener(this);
         setCameraUrl("nc:" + ipAddress + ":" + videoStreamPort);
     }
 
     @Override
     public void setRfidValue(final String rfidValue) {
-        ((RfidSensor) robotElements[1]).setValue(rfidValue);
+        ((RfidSensor) robotElements[0]).setValue(rfidValue);
     }
 
     @Override

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -16,6 +16,7 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
     private final RobotMessageBroker robotMessageBroker;
     private final String hostname;
     private final String ipAddress;
+    private final UnitMessageBroker unitMessageBroker = new UnitMessageBroker(this);
 
     public LegoEv3Tank(final String ipAddress, final String macAddress,
                        final int videoStreamPort, final String image,
@@ -84,14 +85,14 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
     }
 
     @Override
+    public void receivedNewMessage(UnitMessage message) {
+        unitMessageBroker.handle(message);
+    }
+
+    @Override
     public String toString() {
         return "LegoEv3Tank { [Hostname] " + hostname + " [IP] " +
                 ipAddress + " [RoutingID] " + getRoutingId() +
                 " [TeamName] " + getTeamName() + " }";
-    }
-
-    @Override
-    public void receivedNewMessage(UnitMessage msg) {
-        // TODO implement this part
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -16,17 +16,26 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
     private final RobotMessageBroker robotMessageBroker;
     private final String hostname;
     private final String ipAddress;
+    private final String macAddress;
     private final UnitMessageBroker unitMessageBroker = new UnitMessageBroker(this);
 
     public LegoEv3Tank(final String ipAddress, final String macAddress,
                        final int videoStreamPort, final String image,
                        int pushPort, int pullPort, String hostname) {
+        this(ipAddress, macAddress, videoStreamPort, image, hostname,
+                new RobotMessageBroker(pushPort, pullPort));
+    }
+
+    public LegoEv3Tank(final String ipAddress, final String macAddress,
+                       final int videoStreamPort, final String image,
+                       String hostname, final RobotMessageBroker messageBroker) {
         this.robotElements = new IRobotElement[]{new RfidSensor()};
         this.robotActions = new IRobotInput[]{new InputMove(), new InputFire()};
         setImage(image);
         this.hostname = hostname;
         this.ipAddress = ipAddress;
-        robotMessageBroker = new RobotMessageBroker(pushPort, pullPort);
+        this.macAddress = macAddress;
+        this.robotMessageBroker = messageBroker;
         robotMessageBroker.addMessageListener(this);
         setCameraUrl("nc:" + ipAddress + ":" + videoStreamPort);
     }
@@ -40,7 +49,6 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
     public void setColourValue(final String colourValue) {
         ((ColourSensor) robotElements[2]).setValue(colourValue);
     }
-
 
     @Override
     public void sendUnitMessage(final UnitMessage unitMessage) throws MessageNotSentException {
@@ -61,7 +69,6 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
     @Override
     public EnumConnectionState connect() {
         robotMessageBroker.bind();
-        setConnectionState(EnumConnectionState.CONNECTED);
         return getConnectionState();
     }
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -51,7 +51,11 @@ public class LegoEv3Tank extends IRobot implements MessageListenerInterface {
     }
 
     private boolean sendMessageSucceeds(UnitMessage unitMessage) {
-        return robotMessageBroker.send(unitMessage);
+        boolean isSendSuccessful = robotMessageBroker.send(unitMessage);
+        if (!isSendSuccessful) {
+            logback.error("Failed to send UnitMessage to robot " + hostname);
+        }
+        return true;
     }
 
     @Override

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -1,11 +1,28 @@
 package orwell.proxy.robot;
 
 import lejos.mf.common.UnitMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by Michaël Ludmann on 26/06/16.
  */
 public class LegoEv3Tank extends IRobot {
+    private final static Logger logback = LoggerFactory.getLogger(LegoEv3Tank.class);
+    private final IRobotElement[] robotElements;
+    private final IRobotInput[] robotActions;
+
+    public LegoEv3Tank(final String ipAdress, final String macAddress,
+                       final int streamPort, final String image) {
+        this.robotElements = new IRobotElement[]{new RfidSensor()};
+        this.robotActions = new IRobotInput[]{new InputMove(), new InputFire()};
+        setImage(image);
+    }
+
+    public void setRfidValue(final String rfidValue) {
+        ((RfidSensor) robotElements[1]).setValue(rfidValue);
+    }
+
     @Override
     public void sendUnitMessage(UnitMessage unitMessage) {
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -4,6 +4,7 @@ import lejos.mf.common.UnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.ZMQ;
+import orwell.proxy.zmq.RobotMessageBroker;
 
 /**
  * Created by Michaël Ludmann on 26/06/16.
@@ -12,6 +13,7 @@ public class LegoEv3Tank extends IRobot {
     private final static Logger logback = LoggerFactory.getLogger(LegoEv3Tank.class);
     private final IRobotElement[] robotElements;
     private final IRobotInput[] robotActions;
+    private final RobotMessageBroker robotMessageBroker;
 
     public LegoEv3Tank(final String ipAddress, final String macAddress,
                        final int videoStreamPort, final String image,
@@ -19,7 +21,7 @@ public class LegoEv3Tank extends IRobot {
         this.robotElements = new IRobotElement[]{new RfidSensor()};
         this.robotActions = new IRobotInput[]{new InputMove(), new InputFire()};
         setImage(image);
-
+        robotMessageBroker = new RobotMessageBroker(pushPort, subPort);
     }
 
     public void setRfidValue(final String rfidValue) {

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoEv3Tank.java
@@ -1,0 +1,33 @@
+package orwell.proxy.robot;
+
+import lejos.mf.common.UnitMessage;
+
+/**
+ * Created by Michaël Ludmann on 26/06/16.
+ */
+public class LegoEv3Tank extends IRobot {
+    @Override
+    public void sendUnitMessage(UnitMessage unitMessage) {
+
+    }
+
+    @Override
+    public EnumConnectionState connect() {
+        return null;
+    }
+
+    @Override
+    public void closeConnection() {
+
+    }
+
+    @Override
+    public void accept(IRobotElementVisitor visitor) {
+
+    }
+
+    @Override
+    public void accept(IRobotInputVisitor visitor) {
+
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
@@ -61,7 +61,7 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
     }
 
     @Override
-    public void accept(final IRobotInputVisitor visitor) {
+    public void accept(final IRobotInputVisitor visitor) throws MessageNotSentException {
         for (final IRobotInput action : robotActions) {
             action.accept(visitor);
         }
@@ -69,7 +69,7 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
     }
 
     @Override
-    public void sendUnitMessage(final IUnitMessage unitMessage) {
+    public void sendUnitMessage(final IUnitMessage unitMessage) throws MessageNotSentException {
         logback.debug("Sending input to physical device");
         messageFramework.SendMessage((StreamUnitMessage) unitMessage);
     }
@@ -94,6 +94,7 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
         if (EnumConnectionState.CONNECTED == getConnectionState()) {
             messageFramework.close();
         }
+        setConnectionState(EnumConnectionState.NOT_CONNECTED);
     }
 
     @Override

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.IUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.MessageListenerInterface;
 import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.pc.MessageFramework;
@@ -48,8 +48,8 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
 
 
     @Override
-    public void receivedNewMessage(final StreamUnitMessage msg) {
-        unitMessageBroker.handle(msg);
+    public void receivedNewMessage(final UnitMessage msg) {
+        unitMessageBroker.handle((StreamUnitMessage) msg);
     }
 
     @Override
@@ -69,7 +69,7 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
     }
 
     @Override
-    public void sendUnitMessage(final IUnitMessage unitMessage) throws MessageNotSentException {
+    public void sendUnitMessage(final UnitMessage unitMessage) throws MessageNotSentException {
         logback.debug("Sending input to physical device");
         messageFramework.SendMessage((StreamUnitMessage) unitMessage);
     }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
@@ -9,8 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class LegoTank extends IRobot implements MessageListenerInterface {
-    private final static Logger logback = LoggerFactory.getLogger(LegoTank.class);
+public class LegoNxtTank extends IRobot implements MessageListenerInterface {
+    private final static Logger logback = LoggerFactory.getLogger(LegoNxtTank.class);
     private final IRobotElement[] robotElements;
     private final IRobotInput[] robotActions;
     private final NXTInfo nxtInfo;
@@ -18,9 +18,9 @@ public class LegoTank extends IRobot implements MessageListenerInterface {
     private final UnitMessageBroker unitMessageBroker = new UnitMessageBroker(this);
 
 
-    public LegoTank(final String bluetoothName, final String bluetoothId,
-                    final MessageFramework messageFramework,
-                    final ICamera camera, final String image) {
+    public LegoNxtTank(final String bluetoothName, final String bluetoothId,
+                       final MessageFramework messageFramework,
+                       final ICamera camera, final String image) {
         this.robotElements = new IRobotElement[]{camera, new RfidSensor(), new ColourSensor()};
         this.robotActions = new IRobotInput[]{new InputMove(), new InputFire()};
         this.nxtInfo = new NXTInfo(NXTCommFactory.BLUETOOTH, bluetoothName, bluetoothId);
@@ -30,8 +30,8 @@ public class LegoTank extends IRobot implements MessageListenerInterface {
         setCameraUrl(camera.getUrl());
     }
 
-    public LegoTank(final String bluetoothName, final String bluetoothId,
-                    final ICamera camera, final String image) {
+    public LegoNxtTank(final String bluetoothName, final String bluetoothId,
+                       final ICamera camera, final String image) {
         this(bluetoothName, bluetoothId, new MessageFramework(), camera, image);
     }
 
@@ -97,7 +97,7 @@ public class LegoTank extends IRobot implements MessageListenerInterface {
 
     @Override
     public String toString() {
-        return "LegoTank { [BTName] " + nxtInfo.name + " [BT-ID] " +
+        return "LegoNxtTank { [BTName] " + nxtInfo.name + " [BT-ID] " +
                 nxtInfo.deviceAddress + " [RoutingID] " + getRoutingId() +
                 " [TeamName] " + getTeamName() + " }";
     }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
@@ -1,7 +1,8 @@
 package orwell.proxy.robot;
 
+import lejos.mf.common.IUnitMessage;
 import lejos.mf.common.MessageListenerInterface;
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.pc.MessageFramework;
 import lejos.pc.comm.NXTCommFactory;
 import lejos.pc.comm.NXTInfo;
@@ -35,18 +36,19 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
         this(bluetoothName, bluetoothId, new MessageFramework(), camera, image);
     }
 
-
+    @Override
     public void setRfidValue(final String rfidValue) {
         ((RfidSensor) robotElements[1]).setValue(rfidValue);
     }
 
+    @Override
     public void setColourValue(final String colourValue) {
         ((ColourSensor) robotElements[2]).setValue(colourValue);
     }
 
 
     @Override
-    public void receivedNewMessage(final UnitMessage msg) {
+    public void receivedNewMessage(final StreamUnitMessage msg) {
         unitMessageBroker.handle(msg);
     }
 
@@ -67,10 +69,9 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
     }
 
     @Override
-    public void sendUnitMessage(final UnitMessage unitMessage) {
-
+    public void sendUnitMessage(final IUnitMessage unitMessage) {
         logback.debug("Sending input to physical device");
-        messageFramework.SendMessage(unitMessage);
+        messageFramework.SendMessage((StreamUnitMessage) unitMessage);
     }
 
     @Override
@@ -79,13 +80,13 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
 
         final Boolean isConnected = messageFramework.ConnectToNXT(nxtInfo);
         if (isConnected) {
-            this.setConnectionState(EnumConnectionState.CONNECTED);
+            setConnectionState(EnumConnectionState.CONNECTED);
             logback.info("Robot [" + getRoutingId() + "] is connected to the proxy!");
         } else {
-            this.setConnectionState(EnumConnectionState.CONNECTION_FAILED);
+            setConnectionState(EnumConnectionState.CONNECTION_FAILED);
             logback.warn("Robot [" + getRoutingId() + "] failed to connect to the proxy!");
         }
-        return this.getConnectionState();
+        return getConnectionState();
     }
 
     @Override

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
@@ -71,7 +71,8 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
     @Override
     public void sendUnitMessage(final UnitMessage unitMessage) throws MessageNotSentException {
         logback.debug("Sending input to physical device");
-        messageFramework.SendMessage((StreamUnitMessage) unitMessage);
+        StreamUnitMessage streamUnitMessage = new StreamUnitMessage(unitMessage.getMessageType(), unitMessage.getPayload());
+        messageFramework.SendMessage(streamUnitMessage);
     }
 
     @Override

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/LegoNxtTank.java
@@ -46,12 +46,6 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
         ((ColourSensor) robotElements[2]).setValue(colourValue);
     }
 
-
-    @Override
-    public void receivedNewMessage(final UnitMessage msg) {
-        unitMessageBroker.handle((StreamUnitMessage) msg);
-    }
-
     @Override
     public void accept(final IRobotElementVisitor visitor) {
         for (final IRobotElement element : robotElements) {
@@ -99,9 +93,15 @@ public class LegoNxtTank extends IRobot implements MessageListenerInterface {
     }
 
     @Override
+    public void receivedNewMessage(final UnitMessage message) {
+        unitMessageBroker.handle(message);
+    }
+
+    @Override
     public String toString() {
         return "LegoNxtTank { [BTName] " + nxtInfo.name + " [BT-ID] " +
                 nxtInfo.deviceAddress + " [RoutingID] " + getRoutingId() +
                 " [TeamName] " + getTeamName() + " }";
     }
+
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/MessageNotSentException.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/MessageNotSentException.java
@@ -1,0 +1,16 @@
+package orwell.proxy.robot;
+
+/**
+ * Created by Michaël Ludmann on 03/07/16.
+ */
+public class MessageNotSentException extends Exception {
+    final private String hostname;
+
+    public MessageNotSentException(final String hostname) {
+        this.hostname = hostname;
+    }
+
+    public String getMessage() {
+        return "Unable to send message to robot [" + hostname + "]";
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/Registered.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/Registered.java
@@ -24,21 +24,20 @@ public class Registered {
         robot.setRoutingId(serverGameRegistered.getRobotId());
         if (robot.getRoutingId().isEmpty()) {
             robot.setRegistrationState(EnumRegistrationState.REGISTRATION_FAILED);
-            logback.warn("Registration of robot: " + serverGameRegisteredToString(robot) + " FAILED");
+            logback.warn("Registration of robot: " + toString(robot) + " FAILED");
         } else {
             robot.setRegistrationState(EnumRegistrationState.REGISTERED);
             robot.setTeamName(serverGameRegistered.getTeam());
-            logback.info("Registered robot: " + serverGameRegisteredToString(robot));
+            logback.info("Registered robot: " + toString(robot));
         }
     }
 
-    private String serverGameRegisteredToString(final IRobot robot) {
+    private String toString(final IRobot robot) {
         final String string;
         if (null != serverGameRegistered) {
-            string = "ServerGame REGISTERED of Robot [" + robot.getRoutingId() + "]:"
-                    + "\n\t|___final RoutingID: "
-                    + serverGameRegistered.getRobotId() + "\n\t|___team: "
-                    + serverGameRegistered.getTeam();
+            string = "ServerGame REGISTERED of Robot [" + robot.getRoutingId() + "] | " +
+                    "final RoutingID: " + serverGameRegistered.getRobotId() +
+                    " | team: " + serverGameRegistered.getTeam();
         } else {
             string = "ServerGame REGISTERED of Robot [" + robot.getRoutingId()
                     + "] NOT initialized!";

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
@@ -28,8 +28,7 @@ public final class RobotFactory {
     }
 
     private static IRobot getRobot(final ConfigTank configTank) throws ConfigRobotException {
-        switch (configTank.getEnumModel())
-        {
+        switch (configTank.getEnumModel()) {
             case EV3:
                 return buildLegoEv3Tank(configTank);
             case NXT:
@@ -38,8 +37,17 @@ public final class RobotFactory {
         throw new ConfigRobotException(configTank, "EnumModel");
     }
 
-    private static IRobot buildLegoEv3Tank(ConfigTank configTank) {
-        return new LegoEv3Tank();
+    private static LegoEv3Tank buildLegoEv3Tank(ConfigTank configTank) {
+        try {
+            ConfigNetworkInterface cni = configTank.getConfigNetworkInterface("wlan0");
+            return new LegoEv3Tank(cni.getIpAddress(), cni.getMacAddress(),
+                    configTank.getConfigCamera().getPort(), configTank.getImage());
+        } catch (ConfigRobotException e) {
+            logback.error("ConfigNetwork interface of " + configTank.getHostname() +
+                    " is not correct. Robot will not be instantiated. " +
+                    e.getMessage());
+        }
+        return null;
     }
 
     private static IRobot buildLegoNxtTank(ConfigTank configTank) {

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
@@ -40,8 +40,10 @@ public final class RobotFactory {
     private static LegoEv3Tank buildLegoEv3Tank(ConfigTank configTank) {
         try {
             ConfigNetworkInterface cni = configTank.getConfigNetworkInterface("wlan0");
+            ConfigMessaging cm = configTank.getConfigMessaging();
             return new LegoEv3Tank(cni.getIpAddress(), cni.getMacAddress(),
-                    configTank.getConfigCamera().getPort(), configTank.getImage());
+                    configTank.getConfigCamera().getPort(), configTank.getImage(),
+                    cm.getPushPort(), cm.getPullPort());
         } catch (ConfigRobotException e) {
             logback.error("ConfigNetwork interface of " + configTank.getHostname() +
                     " is not correct. Robot will not be instantiated. " +

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
@@ -43,7 +43,7 @@ public final class RobotFactory {
             ConfigMessaging cm = configTank.getConfigMessaging();
             return new LegoEv3Tank(cni.getIpAddress(), cni.getMacAddress(),
                     configTank.getConfigCamera().getPort(), configTank.getImage(),
-                    cm.getPushPort(), cm.getPullPort());
+                    cm.getPushPort(), cm.getPullPort(), configTank.getHostname());
         } catch (ConfigRobotException e) {
             logback.error("ConfigNetwork interface of " + configTank.getHostname() +
                     " is not correct. Robot will not be instantiated. " +

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
@@ -2,10 +2,7 @@ package orwell.proxy.robot;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import orwell.proxy.config.elements.ConfigScout;
-import orwell.proxy.config.elements.ConfigTank;
-import orwell.proxy.config.elements.IConfigCamera;
-import orwell.proxy.config.elements.IConfigRobot;
+import orwell.proxy.config.elements.*;
 
 import java.net.MalformedURLException;
 
@@ -15,7 +12,7 @@ import java.net.MalformedURLException;
 public final class RobotFactory {
     private final static Logger logback = LoggerFactory.getLogger(RobotFactory.class);
 
-    public static IRobot getRobot(final IConfigRobot configRobot) {
+    public static IRobot getRobot(final IConfigRobot configRobot) throws ConfigRobotException {
         if (null == configRobot) {
             return null;
         }
@@ -30,12 +27,27 @@ public final class RobotFactory {
         return null;
     }
 
-    private static IRobot getRobot(final ConfigTank configTank) {
+    private static IRobot getRobot(final ConfigTank configTank) throws ConfigRobotException {
+        switch (configTank.getEnumModel())
+        {
+            case EV3:
+                return buildLegoEv3Tank(configTank);
+            case NXT:
+                return buildLegoNxtTank(configTank);
+        }
+        throw new ConfigRobotException(configTank, "EnumModel");
+    }
+
+    private static IRobot buildLegoEv3Tank(ConfigTank configTank) {
+        return new LegoEv3Tank();
+    }
+
+    private static IRobot buildLegoNxtTank(ConfigTank configTank) {
         final IConfigCamera configCamera = configTank.getConfigCamera();
         if (null == configCamera) {
-            logback.warn("Config of camera is missing for LegoTank: " + configTank.getBluetoothName());
+            logback.warn("Config of camera is missing for LegoNxtTank: " + configTank.getBluetoothName());
             logback.warn("Using dummy camera");
-            return new LegoTank(configTank.getBluetoothName(),
+            return new LegoNxtTank(configTank.getBluetoothName(),
                     configTank.getBluetoothID(), IPWebcam.getDummy(), configTank.getImage());
         } else {
             final IPWebcam ipWebcam;
@@ -48,7 +60,7 @@ public final class RobotFactory {
                 return null;
             }
             //TODO Improve initialization of setImage to get something meaningful from the string (actual image)
-            return new LegoTank(configTank.getBluetoothName(),
+            return new LegoNxtTank(configTank.getBluetoothName(),
                     configTank.getBluetoothID(), ipWebcam, configTank.getImage());
         }
     }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotFactory.java
@@ -15,7 +15,7 @@ import java.net.MalformedURLException;
 public final class RobotFactory {
     private final static Logger logback = LoggerFactory.getLogger(RobotFactory.class);
 
-    public IRobot getRobot(final IConfigRobot configRobot) {
+    public static IRobot getRobot(final IConfigRobot configRobot) {
         if (null == configRobot) {
             return null;
         }
@@ -30,7 +30,7 @@ public final class RobotFactory {
         return null;
     }
 
-    private IRobot getRobot(final ConfigTank configTank) {
+    private static IRobot getRobot(final ConfigTank configTank) {
         final IConfigCamera configCamera = configTank.getConfigCamera();
         if (null == configCamera) {
             logback.warn("Config of camera is missing for LegoTank: " + configTank.getBluetoothName());
@@ -53,7 +53,7 @@ public final class RobotFactory {
         }
     }
 
-    private IRobot getRobot(final ConfigScout configScout) {
+    private static IRobot getRobot(final ConfigScout configScout) {
         logback.warn("Scout config is not handled yet");
         return null;
     }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotGameStateVisitor.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotGameStateVisitor.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.StreamUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.UnitMessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +66,7 @@ public class RobotGameStateVisitor {
 
     private void setDraw(final IRobot robot) throws MessageNotSentException {
         robot.setVictoryState(EnumRobotVictoryState.DRAW);
-        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, DRAW_PAYLOAD_HEADER));
+        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, DRAW_PAYLOAD_HEADER));
         logback.info("Draw info sent to robot " + robot.getRoutingId());
     }
 
@@ -81,13 +81,13 @@ public class RobotGameStateVisitor {
 
     private void setVictory(final IRobot robot) throws MessageNotSentException {
         robot.setVictoryState(EnumRobotVictoryState.WINNER);
-        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, VICTORY_PAYLOAD_HEADER));
+        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, VICTORY_PAYLOAD_HEADER));
         logback.info("Victory info sent to robot " + robot.getRoutingId());
     }
 
     private void setDefeat(final IRobot robot) throws MessageNotSentException {
         robot.setVictoryState(EnumRobotVictoryState.DEFEATED);
-        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, DEFEAT_PAYLOAD_HEADER));
+        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, DEFEAT_PAYLOAD_HEADER));
         logback.info("Defeat info sent to robot " + robot.getRoutingId());
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotGameStateVisitor.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotGameStateVisitor.java
@@ -27,13 +27,13 @@ public class RobotGameStateVisitor {
         this(gameState, null);
     }
 
-    public void visit(final RobotsMap robotsMap) {
+    public void visit(final RobotsMap robotsMap) throws MessageNotSentException {
         for (final IRobot robot : robotsMap.getRegisteredRobots()) {
             setGameState(robot);
         }
     }
 
-    private void setGameState(final IRobot robot) {
+    private void setGameState(final IRobot robot) throws MessageNotSentException {
         switch (gameState) {
             case WAITING_TO_START:
                 setWaitingToStart(robot);
@@ -50,7 +50,7 @@ public class RobotGameStateVisitor {
         }
     }
 
-    private void setFinished(final IRobot robot) {
+    private void setFinished(final IRobot robot) throws MessageNotSentException {
         if (null == winningTeam || winningTeam.equals("")) {
             setDraw(robot);
         } else if (winningTeam.equals(robot.getTeamName())) {
@@ -64,7 +64,7 @@ public class RobotGameStateVisitor {
         logback.warn("Undefined victory state for robot " + robot.getRoutingId() + ". Ignored.");
     }
 
-    private void setDraw(final IRobot robot) {
+    private void setDraw(final IRobot robot) throws MessageNotSentException {
         robot.setVictoryState(EnumRobotVictoryState.DRAW);
         robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, DRAW_PAYLOAD_HEADER));
         logback.info("Draw info sent to robot " + robot.getRoutingId());
@@ -79,13 +79,13 @@ public class RobotGameStateVisitor {
         logback.info("Robot " + robot.getRoutingId() + " is waiting for the game to start");
     }
 
-    private void setVictory(final IRobot robot) {
+    private void setVictory(final IRobot robot) throws MessageNotSentException {
         robot.setVictoryState(EnumRobotVictoryState.WINNER);
         robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, VICTORY_PAYLOAD_HEADER));
         logback.info("Victory info sent to robot " + robot.getRoutingId());
     }
 
-    private void setDefeat(final IRobot robot) {
+    private void setDefeat(final IRobot robot) throws MessageNotSentException {
         robot.setVictoryState(EnumRobotVictoryState.DEFEATED);
         robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, DEFEAT_PAYLOAD_HEADER));
         logback.info("Defeat info sent to robot " + robot.getRoutingId());

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotGameStateVisitor.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotGameStateVisitor.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.common.UnitMessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +66,7 @@ public class RobotGameStateVisitor {
 
     private void setDraw(final IRobot robot) {
         robot.setVictoryState(EnumRobotVictoryState.DRAW);
-        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, DRAW_PAYLOAD_HEADER));
+        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, DRAW_PAYLOAD_HEADER));
         logback.info("Draw info sent to robot " + robot.getRoutingId());
     }
 
@@ -81,13 +81,13 @@ public class RobotGameStateVisitor {
 
     private void setVictory(final IRobot robot) {
         robot.setVictoryState(EnumRobotVictoryState.WINNER);
-        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, VICTORY_PAYLOAD_HEADER));
+        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, VICTORY_PAYLOAD_HEADER));
         logback.info("Victory info sent to robot " + robot.getRoutingId());
     }
 
     private void setDefeat(final IRobot robot) {
         robot.setVictoryState(EnumRobotVictoryState.DEFEATED);
-        robot.sendUnitMessage(new UnitMessage(UnitMessageType.Command, DEFEAT_PAYLOAD_HEADER));
+        robot.sendUnitMessage(new StreamUnitMessage(UnitMessageType.Command, DEFEAT_PAYLOAD_HEADER));
         logback.info("Defeat info sent to robot " + robot.getRoutingId());
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotInputSetVisitor.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotInputSetVisitor.java
@@ -24,18 +24,14 @@ public class RobotInputSetVisitor implements IRobotInputVisitor {
         }
     }
 
-    public String inputToString(final IRobot robot) {
+    public String toString(final IRobot robot) {
         final String string;
         if (null != input) {
             string = "Controller INPUT of Robot [" + robot.getRoutingId() + "]:"
-                    + "\n\t|___Move order: [LEFT] "
-                    + input.getMove().getLeft()
-                    + " \t\t[RIGHT] "
-                    + input.getMove().getRight()
-                    + "\n\t|___Fire order: [WEAPON1] "
-                    + input.getFire().getWeapon1()
-                    + " \t[WEAPON2] "
-                    + input.getFire().getWeapon2();
+                    + " | Move order: [LEFT] " + input.getMove().getLeft()
+                    + " [RIGHT] " + input.getMove().getRight()
+                    + " | Fire order: [WEAPON1] " + input.getFire().getWeapon1()
+                    + " [WEAPON2] " + input.getFire().getWeapon2();
         } else {
             string = "Controller INPUT of Robot [" + robot.getRoutingId()
                     + "] NOT initialized!";

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotInputSetVisitor.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotInputSetVisitor.java
@@ -75,9 +75,7 @@ public class RobotInputSetVisitor implements IRobotInputVisitor {
      * (meaning it is not worth sending it to the robot)
      */
     private boolean isEmpty(final Controller.Input input) {
-        return (null == input) ||
-                !(input.hasFire() &&
-                        (input.getFire().getWeapon1() || input.getFire().getWeapon2()));
+        return (null == input) || !(input.hasFire());
     }
 
     @Override

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotInputSetVisitor.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotInputSetVisitor.java
@@ -77,11 +77,11 @@ public class RobotInputSetVisitor implements IRobotInputVisitor {
     private boolean isEmpty(final Controller.Input input) {
         return (null == input) ||
                 !(input.hasFire() &&
-                (input.getFire().getWeapon1() || input.getFire().getWeapon2()));
+                        (input.getFire().getWeapon1() || input.getFire().getWeapon2()));
     }
 
     @Override
-    public void visit(final IRobot robot) {
+    public void visit(final IRobot robot) throws MessageNotSentException {
 
         if (null != this.inputMove && this.inputMove.hasMove()) {
             inputMove.sendUnitMessageTo(robot);

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotsMap.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/RobotsMap.java
@@ -102,7 +102,7 @@ public class RobotsMap implements IRobotsMap {
     }
 
     @Override
-    public void accept(final RobotGameStateVisitor visitor) {
+    public void accept(final RobotGameStateVisitor visitor) throws Exception {
         visitor.visit(this);
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
@@ -9,9 +9,9 @@ import org.slf4j.LoggerFactory;
  */
 class UnitMessageBroker {
     private final static Logger logback = LoggerFactory.getLogger(UnitMessageBroker.class);
-    private final LegoTank tank;
+    private final LegoNxtTank tank;
 
-    public UnitMessageBroker(final LegoTank tank) {
+    public UnitMessageBroker(final LegoNxtTank tank) {
         this.tank = tank;
     }
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,50 +9,50 @@ import org.slf4j.LoggerFactory;
  */
 class UnitMessageBroker {
     private final static Logger logback = LoggerFactory.getLogger(UnitMessageBroker.class);
-    private final LegoNxtTank tank;
+    private final IRobot robot;
 
-    public UnitMessageBroker(final LegoNxtTank tank) {
-        this.tank = tank;
+    public UnitMessageBroker(final IRobot robot) {
+        this.robot = robot;
     }
 
-    public void handle(final UnitMessage unitMessage) {
+    public void handle(final StreamUnitMessage streamUnitMessage) {
 
-        switch (unitMessage.getMsgType()) {
+        switch (streamUnitMessage.getMessageType()) {
             case Stop:
                 onMsgStop();
                 break;
             case Rfid:
-                onMsgRfid(unitMessage.getPayload());
+                onMsgRfid(streamUnitMessage.getPayload());
                 break;
             case Command:
-                onMsgCommand(unitMessage.getPayload());
+                onMsgCommand(streamUnitMessage.getPayload());
                 break;
             case Colour:
-                onMsgColour(unitMessage.getPayload());
+                onMsgColour(streamUnitMessage.getPayload());
                 break;
             default:
-                onMsgNotDefined(unitMessage.getPayload());
+                onMsgNotDefined(streamUnitMessage.getPayload());
                 break;
         }
     }
 
     private void onMsgStop() {
 
-        logback.info("Tank " + tank.getRoutingId() + " is stopping");
-        tank.setConnectionState(EnumConnectionState.NOT_CONNECTED);
-        tank.closeConnection();
+        logback.info("Tank " + robot.getRoutingId() + " is stopping");
+        robot.setConnectionState(EnumConnectionState.NOT_CONNECTED);
+        robot.closeConnection();
     }
 
     private void onMsgRfid(final String rfidValue) {
 
         logback.debug("RFID info received: " + rfidValue);
-        tank.setRfidValue(rfidValue);
+        robot.setRfidValue(rfidValue);
     }
 
     private void onMsgColour(final String colourValue) {
 
         logback.debug("Colour info received: " + colourValue);
-        tank.setColourValue(colourValue);
+        robot.setColourValue(colourValue);
     }
 
     private void onMsgCommand(final String msg) {

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.StreamUnitMessage;
+import lejos.mf.common.UnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,23 +15,23 @@ class UnitMessageBroker {
         this.robot = robot;
     }
 
-    public void handle(final StreamUnitMessage streamUnitMessage) {
+    public void handle(final UnitMessage unitMessage) {
 
-        switch (streamUnitMessage.getMessageType()) {
+        switch (unitMessage.getMessageType()) {
             case Stop:
                 onMsgStop();
                 break;
             case Rfid:
-                onMsgRfid(streamUnitMessage.getPayload());
+                onMsgRfid(unitMessage.getPayload());
                 break;
             case Command:
-                onMsgCommand(streamUnitMessage.getPayload());
+                onMsgCommand(unitMessage.getPayload());
                 break;
             case Colour:
-                onMsgColour(streamUnitMessage.getPayload());
+                onMsgColour(unitMessage.getPayload());
                 break;
             default:
-                onMsgNotDefined(streamUnitMessage.getPayload());
+                onMsgNotDefined(unitMessage.getPayload());
                 break;
         }
     }

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
@@ -16,7 +16,8 @@ class UnitMessageBroker {
     }
 
     public void handle(final UnitMessage unitMessage) {
-
+        if (unitMessage == null)
+            return;
         switch (unitMessage.getMessageType()) {
             case Stop:
                 onMsgStop();

--- a/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/robot/UnitMessageBroker.java
@@ -31,6 +31,9 @@ class UnitMessageBroker {
             case Colour:
                 onMsgColour(unitMessage.getPayload());
                 break;
+            case Connection:
+                onMsgConnection(unitMessage.getPayload());
+                break;
             default:
                 onMsgNotDefined(unitMessage.getPayload());
                 break;
@@ -60,6 +63,15 @@ class UnitMessageBroker {
 
         logback.debug("Tank is sending a command: " + msg);
         logback.debug("This command will not be processed");
+    }
+
+    private void onMsgConnection(final String payload) {
+        logback.debug("Tank sent a connection message: " + payload);
+        if (payload.equalsIgnoreCase("connected")) {
+            robot.setConnectionState(EnumConnectionState.CONNECTED);
+        } else if (payload.equalsIgnoreCase("close")) {
+            robot.setConnectionState(EnumConnectionState.NOT_CONNECTED);
+        }
     }
 
     private void onMsgNotDefined(final String msg) {

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/GameServerMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/GameServerMessageBroker.java
@@ -10,9 +10,9 @@ import java.util.ArrayList;
 /**
  * Created by Michael Ludmann on 08/03/15.
  */
-public class ZmqMessageBroker implements IZmqMessageBroker {
+public class GameServerMessageBroker implements IGameServerMessageBroker {
 
-    private final static Logger logback = LoggerFactory.getLogger(ZmqMessageBroker.class);
+    private final static Logger logback = LoggerFactory.getLogger(GameServerMessageBroker.class);
     private static final long THREAD_SLEEP_MS = 10;
     private final Object rXguard;
     private final ZMQ.Context context;
@@ -29,10 +29,10 @@ public class ZmqMessageBroker implements IZmqMessageBroker {
     private volatile long baseTimeMs;
     private int nbBadMessages;
 
-    public ZmqMessageBroker(final long receiveTimeoutMs,
-                            final int senderLinger,
-                            final int receiverLinger,
-                            final ArrayList<IFilter> filterList) {
+    public GameServerMessageBroker(final long receiveTimeoutMs,
+                                   final int senderLinger,
+                                   final int receiverLinger,
+                                   final ArrayList<IFilter> filterList) {
         logback.info("Constructor -- IN");
         socketTimeoutMs = receiveTimeoutMs;
         isSocketTimeoutSet = 0 < receiveTimeoutMs;
@@ -53,9 +53,9 @@ public class ZmqMessageBroker implements IZmqMessageBroker {
         logback.info("Constructor -- OUT");
     }
 
-    public ZmqMessageBroker(final long receiveTimeoutMs,
-                            final int senderLinger,
-                            final int receiverLinger) {
+    public GameServerMessageBroker(final long receiveTimeoutMs,
+                                   final int senderLinger,
+                                   final int receiverLinger) {
         this(receiveTimeoutMs, senderLinger, receiverLinger, null);
     }
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/IGameServerMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/IGameServerMessageBroker.java
@@ -3,7 +3,7 @@ package orwell.proxy.zmq;
 /**
  * Created by Michaël Ludmann on 03/05/15.
  */
-public interface IZmqMessageBroker {
+public interface IGameServerMessageBroker {
 
     /**
      * Decide whether to handle two identical successive messages or to ignore the second

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/IServerGameMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/IServerGameMessageBroker.java
@@ -3,7 +3,7 @@ package orwell.proxy.zmq;
 /**
  * Created by Michaël Ludmann on 03/05/15.
  */
-public interface IGameServerMessageBroker {
+public interface IServerGameMessageBroker {
 
     /**
      * Decide whether to handle two identical successive messages or to ignore the second

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 public class RobotMessageBroker {
     private final static Logger logback = LoggerFactory.getLogger(RobotMessageBroker.class);
     private static final String BINDING_ADDRESS = "tcp://0.0.0.0";
+    private static final long THREAD_SLEEP_POST_CONNECT_MS = 1000;
     private final ZMQ.Context context;
     private final ZMQ.Socket sender;
     private final ZMQ.Socket receiver;
@@ -30,7 +31,7 @@ public class RobotMessageBroker {
         this.pushPort = pushPort;
         this.pullPort = pullPort;
 
-        context = ZMQ.context(1);
+        context = ZMQ.context(2);
         sender = context.socket(ZMQ.PUSH);
         receiver = context.socket(ZMQ.PULL);
 
@@ -45,8 +46,14 @@ public class RobotMessageBroker {
         sender.bind(BINDING_ADDRESS + ":" + pushPort);
         receiver.bind(BINDING_ADDRESS + ":" + pullPort);
         isConnected = true;
-        logback.info("Proxy is binding on ports " + pushPort + " (push) and " + pullPort + " (pull)");
 
+        try {
+            Thread.sleep(THREAD_SLEEP_POST_CONNECT_MS);
+        } catch (InterruptedException e) {
+            logback.error(e.getMessage());
+        }
+
+        logback.info("Proxy is binding on ports " + pushPort + " (push) and " + pullPort + " (pull) for robot communication");
         reader.start();
     }
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -1,12 +1,51 @@
 package orwell.proxy.zmq;
 
+import lejos.mf.common.IUnitMessage;
+import lejos.mf.common.SimpleUnitMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.ZMQ;
+
 /**
  * Created by Michaël Ludmann on 27/06/16.
  */
 public class RobotMessageBroker {
+    private final static Logger logback = LoggerFactory.getLogger(RobotMessageBroker.class);
+    private static final String BINDING_ADDRESS = "tcp://0.0.0.0";
+    private final ZMQ.Context context;
+    private final ZMQ.Socket sender;
+    private final ZMQ.Socket receiver;
+    private final int pushPort;
+    private final int pullPort;
 
+    public RobotMessageBroker(int pushPort, int pullPort) {
+        this.pushPort = pushPort;
+        this.pullPort = pullPort;
 
-    public RobotMessageBroker(int pushPort, int subPort) {
+        context = ZMQ.context(1);
+        sender = context.socket(ZMQ.PUSH);
+        receiver = context.socket(ZMQ.PULL);
 
+        sender.setLinger(1000);
+        receiver.setLinger(1000);
+    }
+
+    public void bind() {
+        logback.info("Proxy is starting binding on ports " + pushPort + " and " + pullPort);
+        sender.bind(BINDING_ADDRESS + ":" + pushPort);
+        receiver.bind(BINDING_ADDRESS + ":" + pullPort);
+        logback.debug("Proxy is done binding");
+    }
+
+    public void close() {
+        sender.close();
+        receiver.close();
+        context.term();
+        logback.info("All sockets of are now closed");
+    }
+
+    public void send(SimpleUnitMessage unitMessage) {
+        logback.debug("Sending input to physical device");
+        sender.send(unitMessage.toString());
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -1,9 +1,14 @@
 package orwell.proxy.zmq;
 
+import lejos.mf.common.MessageListenerInterface;
 import lejos.mf.common.UnitMessage;
+import lejos.mf.common.UnitMessageBuilder;
+import lejos.mf.common.exception.UnitMessageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.ZMQ;
+
+import java.util.ArrayList;
 
 /**
  * Created by Michaël Ludmann on 27/06/16.
@@ -16,8 +21,12 @@ public class RobotMessageBroker {
     private final ZMQ.Socket receiver;
     private final int pushPort;
     private final int pullPort;
+    private final RobotZmqReader reader;
+    private ArrayList<MessageListenerInterface> messageListeners;
+    private boolean isConnected = false;
 
     public RobotMessageBroker(int pushPort, int pullPort) {
+        messageListeners = new ArrayList<>();
         this.pushPort = pushPort;
         this.pullPort = pullPort;
 
@@ -27,15 +36,22 @@ public class RobotMessageBroker {
 
         sender.setLinger(1000);
         receiver.setLinger(1000);
+
+        reader = new RobotZmqReader();
+        reader.setDaemon(true);
     }
 
     public void bind() {
         sender.bind(BINDING_ADDRESS + ":" + pushPort);
         receiver.bind(BINDING_ADDRESS + ":" + pullPort);
+        isConnected = true;
         logback.info("Proxy is binding on ports " + pushPort + " (push) and " + pullPort + " (pull)");
+
+        reader.start();
     }
 
     public void close() {
+        isConnected = false;
         sender.close();
         receiver.close();
         context.term();
@@ -45,5 +61,42 @@ public class RobotMessageBroker {
     public boolean send(UnitMessage unitMessage) {
         logback.debug("Sending message to physical device");
         return sender.send(unitMessage.toString());
+    }
+
+    public void addMessageListener(MessageListenerInterface messageListenerInterface) {
+        messageListeners.add(messageListenerInterface);
+    }
+
+    private class RobotZmqReader extends Thread {
+        @Override
+        public void run() {
+            while (isConnected) {
+                listenForNewMessage();
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    logback.error(e.getMessage());
+                }
+            }
+        }
+
+        private void listenForNewMessage() {
+            String msg = receiver.recvStr(1); // do not block thread waiting for a message
+            if (msg != null) {
+                logback.debug("Message received: " + msg);
+            }
+            try {
+                UnitMessage unitMessage = UnitMessageBuilder.build(msg);
+                receivedNewMessage(unitMessage);
+            } catch (UnitMessageException e) {
+                logback.debug("Unit Message Exception: " + e.getMessage());
+            }
+        }
+
+        private void receivedNewMessage(UnitMessage unitMessage) {
+            for (MessageListenerInterface listener : messageListeners) {
+                listener.receivedNewMessage(unitMessage);
+            }
+        }
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -1,6 +1,6 @@
 package orwell.proxy.zmq;
 
-import lejos.mf.common.SimpleUnitMessage;
+import lejos.mf.common.UnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.ZMQ;
@@ -30,7 +30,7 @@ public class RobotMessageBroker {
     }
 
     public void bind() {
-        logback.info("Proxy is starting binding on ports " + pushPort + " and " + pullPort);
+        logback.info("Proxy is starting binding on ports " + pushPort + " (push) and " + pullPort + " (pull)");
         sender.bind(BINDING_ADDRESS + ":" + pushPort);
         receiver.bind(BINDING_ADDRESS + ":" + pullPort);
         logback.debug("Proxy is done binding");
@@ -43,8 +43,8 @@ public class RobotMessageBroker {
         logback.info("All sockets of are now closed");
     }
 
-    public boolean send(SimpleUnitMessage unitMessage) {
-        logback.debug("Sending input to physical device");
+    public boolean send(UnitMessage unitMessage) {
+        logback.debug("Sending message to physical device");
         return sender.send(unitMessage.toString());
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -30,10 +30,9 @@ public class RobotMessageBroker {
     }
 
     public void bind() {
-        logback.info("Proxy is starting binding on ports " + pushPort + " (push) and " + pullPort + " (pull)");
         sender.bind(BINDING_ADDRESS + ":" + pushPort);
         receiver.bind(BINDING_ADDRESS + ":" + pullPort);
-        logback.debug("Proxy is done binding");
+        logback.info("Proxy is binding on ports " + pushPort + " (push) and " + pullPort + " (pull)");
     }
 
     public void close() {

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 public class RobotMessageBroker {
     private final static Logger logback = LoggerFactory.getLogger(RobotMessageBroker.class);
     private static final String BINDING_ADDRESS = "tcp://0.0.0.0";
+    // This sleep is very important - we tested this value to be enough. Without it, we might lose the first message sent by the server.
     private static final long THREAD_SLEEP_POST_CONNECT_MS = 1000;
     private final ZMQ.Context context;
     private final ZMQ.Socket sender;

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -1,6 +1,5 @@
 package orwell.proxy.zmq;
 
-import lejos.mf.common.IUnitMessage;
 import lejos.mf.common.SimpleUnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +43,8 @@ public class RobotMessageBroker {
         logback.info("All sockets of are now closed");
     }
 
-    public void send(SimpleUnitMessage unitMessage) {
+    public boolean send(SimpleUnitMessage unitMessage) {
         logback.debug("Sending input to physical device");
-        sender.send(unitMessage.toString());
+        return sender.send(unitMessage.toString());
     }
 }

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/RobotMessageBroker.java
@@ -1,0 +1,12 @@
+package orwell.proxy.zmq;
+
+/**
+ * Created by Michaël Ludmann on 27/06/16.
+ */
+public class RobotMessageBroker {
+
+
+    public RobotMessageBroker(int pushPort, int subPort) {
+
+    }
+}

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/ServerGameMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/ServerGameMessageBroker.java
@@ -135,7 +135,7 @@ public class ServerGameMessageBroker implements IServerGameMessageBroker {
                 (System.currentTimeMillis() - baseTimeMs > socketTimeoutMs);
     }
 
-    private class ZmqReader extends Thread {
+    public class ZmqReader extends Thread {
         ZmqMessageBOM previousZmqMessage;
         ZmqMessageBOM newZmqMessage;
 

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/ServerGameMessageBroker.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/ServerGameMessageBroker.java
@@ -10,9 +10,9 @@ import java.util.ArrayList;
 /**
  * Created by Michael Ludmann on 08/03/15.
  */
-public class GameServerMessageBroker implements IGameServerMessageBroker {
+public class ServerGameMessageBroker implements IServerGameMessageBroker {
 
-    private final static Logger logback = LoggerFactory.getLogger(GameServerMessageBroker.class);
+    private final static Logger logback = LoggerFactory.getLogger(ServerGameMessageBroker.class);
     private static final long THREAD_SLEEP_MS = 10;
     private final Object rXguard;
     private final ZMQ.Context context;
@@ -29,7 +29,7 @@ public class GameServerMessageBroker implements IGameServerMessageBroker {
     private volatile long baseTimeMs;
     private int nbBadMessages;
 
-    public GameServerMessageBroker(final long receiveTimeoutMs,
+    public ServerGameMessageBroker(final long receiveTimeoutMs,
                                    final int senderLinger,
                                    final int receiverLinger,
                                    final ArrayList<IFilter> filterList) {
@@ -53,7 +53,7 @@ public class GameServerMessageBroker implements IGameServerMessageBroker {
         logback.info("Constructor -- OUT");
     }
 
-    public GameServerMessageBroker(final long receiveTimeoutMs,
+    public ServerGameMessageBroker(final long receiveTimeoutMs,
                                    final int senderLinger,
                                    final int receiverLinger) {
         this(receiveTimeoutMs, senderLinger, receiverLinger, null);

--- a/proxy-robots-module/src/main/java/orwell/proxy/zmq/ZmqMessageBOM.java
+++ b/proxy-robots-module/src/main/java/orwell/proxy/zmq/ZmqMessageBOM.java
@@ -56,7 +56,7 @@ public class ZmqMessageBOM {
 
         final EnumMessageType type = getEnumTypeFromTypeString(typeString);
 
-        logback.debug("Message parsed: [RoutingID] " + routingId + " [TYPE] " + type);
+        //logback.debug("Message parsed: [RoutingID] " + routingId + " [TYPE] " + type);
         return new ZmqMessageBOM(routingId, type, messageBodyBytes);
     }
 

--- a/proxy-robots-module/src/main/resources/logback.xml
+++ b/proxy-robots-module/src/main/resources/logback.xml
@@ -21,10 +21,10 @@
         </encoder>
     </appender>
 
-    <root level="trace">
+    <root level="TRACE">
         <appender-ref ref="FILE"/>
     </root>
-    <root level="debug">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/proxy-robots-module/src/test/java/orwell/proxy/ProxyRobotsTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/ProxyRobotsTest.java
@@ -11,6 +11,7 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.config.ConfigFactory;
+import orwell.proxy.config.elements.ConfigRobotException;
 import orwell.proxy.config.source.ConfigurationResource;
 import orwell.proxy.mock.MockedTank;
 import orwell.proxy.robot.EnumRegistrationState;
@@ -176,7 +177,7 @@ public class ProxyRobotsTest {
     }
 
     @Test
-    public void testInitializeTanksFromConfig() {
+    public void testInitializeTanksFromConfig() throws ConfigRobotException {
         instantiateBasicProxyRobots();
 
         myProxyRobots.initializeRobotsFromConfig();
@@ -222,7 +223,7 @@ public class ProxyRobotsTest {
     }
 
     @Test
-    public void testStart_noUdpDiscovery() {
+    public void testStart_noUdpDiscovery() throws ConfigRobotException {
         logback.debug(">>>>>>>>> IN");
 
         // Build Mock of ZmqMessageBroker
@@ -255,7 +256,7 @@ public class ProxyRobotsTest {
     }
 
     @Test
-    public void testStart_udpDiscovery() {
+    public void testStart_udpDiscovery() throws ConfigRobotException {
         // Build Mock of ZmqMessageBroker
         final Capture<String> capturePushAddress = new Capture<>();
         final Capture<String> captureSubscribeAddress = new Capture<>();
@@ -300,7 +301,7 @@ public class ProxyRobotsTest {
      * server with the beacon finder, then we fallback on configuration data
      * found in the xml file
      */
-    public void testStart_udpDiscoveryWithZeroAttempt() {
+    public void testStart_udpDiscoveryWithZeroAttempt() throws ConfigRobotException {
         // Build Mock of ZmqMessageBroker
         final Capture<String> capturePushAddress = new Capture<>();
         final Capture<String> captureSubscribeAddress = new Capture<>();
@@ -378,7 +379,7 @@ public class ProxyRobotsTest {
     }
 
     @Test
-    public void testGetNbOutgoingMessageFiltered() {
+    public void testGetNbOutgoingMessageFiltered() throws ConfigRobotException {
         instantiateBasicProxyRobots();
         myProxyRobots.start();
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/ProxyRobotsTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/ProxyRobotsTest.java
@@ -398,6 +398,9 @@ public class ProxyRobotsTest {
                         getBytesRegistered())
         );
 
+        // Make robot unable to send unit message
+        ((MockedTank) myProxyRobots.robotsMap.get(mockedTank.getRoutingId())).makeUnableToSendUnitMessages();
+
         // Now simulate reception of a INPUT message
         myProxyRobots.receivedNewZmq(
                 new ZmqMessageBOM(mockedTank.getRoutingId(),

--- a/proxy-robots-module/src/test/java/orwell/proxy/ProxyRobotsTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/ProxyRobotsTest.java
@@ -18,9 +18,9 @@ import orwell.proxy.robot.EnumRegistrationState;
 import orwell.proxy.robot.EnumRobotVictoryState;
 import orwell.proxy.robot.RobotsMap;
 import orwell.proxy.udp.UdpBeaconFinder;
+import orwell.proxy.zmq.GameServerMessageBroker;
 import orwell.proxy.zmq.IZmqMessageListener;
 import orwell.proxy.zmq.ZmqMessageBOM;
-import orwell.proxy.zmq.ZmqMessageBroker;
 
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
@@ -46,7 +46,7 @@ public class ProxyRobotsTest {
     private static final long WAIT_TIMEOUT_MS = 500; // has to be greater than ProxyRobots.THREAD_SLEEP_MS
     private static final long RECEIVE_TIMEOUT = 500;
     private static final String ROUTING_ID_ALL = "all_robots";
-    private ZmqMessageBroker mockedZmqMessageBroker;
+    private GameServerMessageBroker mockedGameServerMessageBroker;
     private ConfigFactory configFactory;
     private RobotsMap robotsMap;
     private ConfigurationResource configuration;
@@ -59,7 +59,7 @@ public class ProxyRobotsTest {
     public void setUp() {
         logback.debug(">>>>>>>>> IN");
         configuration = new ConfigurationResource(CONFIGURATION_RESOURCE_PATH);
-        mockedZmqMessageBroker = createNiceMock(ZmqMessageBroker.class);
+        mockedGameServerMessageBroker = createNiceMock(GameServerMessageBroker.class);
 
         // Build Mock of Tank
         mockedTank = new MockedTank();
@@ -102,17 +102,17 @@ public class ProxyRobotsTest {
     }
 
     private void instantiateBasicProxyRobots() {
-        // Build Mock of ZmqMessageBroker
-        mockedZmqMessageBroker.addZmqMessageListener(anyObject(IZmqMessageListener.class));
+        // Build Mock of GameServerMessageBroker
+        mockedGameServerMessageBroker.addZmqMessageListener(anyObject(IZmqMessageListener.class));
         expectLastCall();
 
-        expect(mockedZmqMessageBroker.sendZmqMessage((ZmqMessageBOM) anyObject())).andReturn(true).anyTimes();
-        expect(mockedZmqMessageBroker.isConnectedToServer()).andReturn(true).anyTimes();
+        expect(mockedGameServerMessageBroker.sendZmqMessage((ZmqMessageBOM) anyObject())).andReturn(true).anyTimes();
+        expect(mockedGameServerMessageBroker.isConnectedToServer()).andReturn(true).anyTimes();
 
-        replay(mockedZmqMessageBroker);
+        replay(mockedGameServerMessageBroker);
 
         // Instantiate main class with mock parameters
-        myProxyRobots = new ProxyRobots(mockedZmqMessageBroker, configFactory,
+        myProxyRobots = new ProxyRobots(mockedGameServerMessageBroker, configFactory,
                 robotsMap);
     }
 
@@ -192,13 +192,13 @@ public class ProxyRobotsTest {
     public void testSendServerRobotState() throws Exception {
         logback.debug(">>>>>>>>> IN");
 
-        // Build Mock of ZmqMessageBroker
+        // Build Mock of GameServerMessageBroker
         final Capture<ZmqMessageBOM> captureMsg = new Capture<>();
-        expect(mockedZmqMessageBroker.sendZmqMessage(capture(captureMsg))).andReturn(true).atLeastOnce();
-        replay(mockedZmqMessageBroker);
+        expect(mockedGameServerMessageBroker.sendZmqMessage(capture(captureMsg))).andReturn(true).atLeastOnce();
+        replay(mockedGameServerMessageBroker);
 
         // Instantiate main class with mock parameters
-        myProxyRobots = new ProxyRobots(mockedZmqMessageBroker, configFactory,
+        myProxyRobots = new ProxyRobots(mockedGameServerMessageBroker, configFactory,
                 robotsMap);
 
         myProxyRobots.connectToRobots();
@@ -216,7 +216,7 @@ public class ProxyRobotsTest {
         myProxyRobots.sendServerRobotStates();
 
         // ProxyRobot is expected to send a ServerRobotState message
-        verify(mockedZmqMessageBroker);
+        verify(mockedGameServerMessageBroker);
         assertEquals(EnumMessageType.SERVER_ROBOT_STATE, captureMsg.getValue().getMessageType());
         assertEquals("RoutingId is supposed to have changed to the one provided by registered",
                 ProtobufTest.REGISTERED_ROUTING_ID, captureMsg.getValue().getRoutingId());
@@ -226,16 +226,16 @@ public class ProxyRobotsTest {
     public void testStart_noUdpDiscovery() throws ConfigRobotException {
         logback.debug(">>>>>>>>> IN");
 
-        // Build Mock of ZmqMessageBroker
+        // Build Mock of GameServerMessageBroker
         final Capture<String> capturePushAddress = new Capture<>();
         final Capture<String> captureSubscribeAddress = new Capture<>();
-        expect(mockedZmqMessageBroker.connectToServer(capture(capturePushAddress), capture(captureSubscribeAddress))).andReturn(true);
-        mockedZmqMessageBroker.close();
+        expect(mockedGameServerMessageBroker.connectToServer(capture(capturePushAddress), capture(captureSubscribeAddress))).andReturn(true);
+        mockedGameServerMessageBroker.close();
         expectLastCall().once();
-        replay(mockedZmqMessageBroker);
+        replay(mockedGameServerMessageBroker);
 
         // Instantiate main class with mock parameters
-        myProxyRobots = new ProxyRobots(mockedZmqMessageBroker, configFactory,
+        myProxyRobots = new ProxyRobots(mockedGameServerMessageBroker, configFactory,
                 robotsMap);
 
         myProxyRobots.start();
@@ -245,7 +245,7 @@ public class ProxyRobotsTest {
         // this tank fails to connect because of wrong settings, so
         // the communication service should quickly stop and close
         // the message framework proxy
-        verify(mockedZmqMessageBroker);
+        verify(mockedGameServerMessageBroker);
 
         // messageBroker.connectToServer() was called with parameters
         // coming from the configuration file
@@ -257,13 +257,13 @@ public class ProxyRobotsTest {
 
     @Test
     public void testStart_udpDiscovery() throws ConfigRobotException {
-        // Build Mock of ZmqMessageBroker
+        // Build Mock of GameServerMessageBroker
         final Capture<String> capturePushAddress = new Capture<>();
         final Capture<String> captureSubscribeAddress = new Capture<>();
-        expect(mockedZmqMessageBroker.connectToServer(capture(capturePushAddress), capture(captureSubscribeAddress))).andReturn(true);
-        mockedZmqMessageBroker.close();
+        expect(mockedGameServerMessageBroker.connectToServer(capture(capturePushAddress), capture(captureSubscribeAddress))).andReturn(true);
+        mockedGameServerMessageBroker.close();
         expectLastCall().once();
-        replay(mockedZmqMessageBroker);
+        replay(mockedGameServerMessageBroker);
 
         // Simulate a working UDP beacon finder
         final UdpBeaconFinder udpBeaconFinder = createNiceMock(UdpBeaconFinder.class);
@@ -273,7 +273,7 @@ public class ProxyRobotsTest {
         replay(udpBeaconFinder);
 
         // Instantiate main class with mock parameters
-        myProxyRobots = new ProxyRobots(udpBeaconFinder, mockedZmqMessageBroker,
+        myProxyRobots = new ProxyRobots(udpBeaconFinder, mockedGameServerMessageBroker,
                 configFactory, robotsMap);
 
         myProxyRobots.start();
@@ -283,7 +283,7 @@ public class ProxyRobotsTest {
         // this tank fails to connect because of wrong settings, so
         // the communication service should quickly stop and close
         // the message framework proxy
-        verify(mockedZmqMessageBroker);
+        verify(mockedGameServerMessageBroker);
 
         // Check that udpBeacon has been correctly used (broadcastAndGetServerAddress() and
         // hasFoundServer() were called)
@@ -302,13 +302,13 @@ public class ProxyRobotsTest {
      * found in the xml file
      */
     public void testStart_udpDiscoveryWithZeroAttempt() throws ConfigRobotException {
-        // Build Mock of ZmqMessageBroker
+        // Build Mock of GameServerMessageBroker
         final Capture<String> capturePushAddress = new Capture<>();
         final Capture<String> captureSubscribeAddress = new Capture<>();
-        expect(mockedZmqMessageBroker.connectToServer(capture(capturePushAddress), capture(captureSubscribeAddress))).andReturn(true);
-        mockedZmqMessageBroker.close();
+        expect(mockedGameServerMessageBroker.connectToServer(capture(capturePushAddress), capture(captureSubscribeAddress))).andReturn(true);
+        mockedGameServerMessageBroker.close();
         expectLastCall().once();
-        replay(mockedZmqMessageBroker);
+        replay(mockedGameServerMessageBroker);
 
         // Simulate a failure of the UDP beacon finder
         // (or that we set 'attempts' to 0)
@@ -317,7 +317,7 @@ public class ProxyRobotsTest {
         replay(udpBeaconFinder);
 
         // Instantiate main class with mock parameters
-        myProxyRobots = new ProxyRobots(udpBeaconFinder, mockedZmqMessageBroker,
+        myProxyRobots = new ProxyRobots(udpBeaconFinder, mockedGameServerMessageBroker,
                 configFactory, robotsMap);
 
         myProxyRobots.start();
@@ -327,7 +327,7 @@ public class ProxyRobotsTest {
         // this tank fails to connect because of wrong settings, so
         // the communication service should quickly stop and close
         // the message framework proxy
-        verify(mockedZmqMessageBroker);
+        verify(mockedGameServerMessageBroker);
 
         // Check that udpBeacon has been correctly used (broadcastAndGetServerAddress() and
         // hasFoundServer() were called)
@@ -398,7 +398,7 @@ public class ProxyRobotsTest {
      */
     public void testProxyRobots_StartWithMockTank() throws Exception {
         // Instantiate main class with mock tank, but real zmq conf
-        myProxyRobots = new ProxyRobots(new ZmqMessageBroker(RECEIVE_TIMEOUT, 1000, 1000), configFactory,
+        myProxyRobots = new ProxyRobots(new GameServerMessageBroker(RECEIVE_TIMEOUT, 1000, 1000), configFactory,
                 robotsMap);
         myProxyRobots.start();
 
@@ -425,7 +425,7 @@ public class ProxyRobotsTest {
 
         // Game is still playing, there is then no winner
         assertEquals(EnumRobotVictoryState.WAITING_FOR_START, (myProxyRobots.robotsMap.
-                        get(ProtobufTest.REGISTERED_ROUTING_ID)).getVictoryState()
+                get(ProtobufTest.REGISTERED_ROUTING_ID)).getVictoryState()
         );
 
         // Now simulate reception of a GAME_STATE message
@@ -438,7 +438,7 @@ public class ProxyRobotsTest {
         );
         // Tank victory state was changed accordingly to PLAYING
         assertEquals(EnumRobotVictoryState.PLAYING, (myProxyRobots.robotsMap.
-                        get(ProtobufTest.REGISTERED_ROUTING_ID)).getVictoryState()
+                get(ProtobufTest.REGISTERED_ROUTING_ID)).getVictoryState()
         );
 
         // Now simulate reception of a GAME_STATE message
@@ -452,7 +452,7 @@ public class ProxyRobotsTest {
 
         // Tank victory state was changed accordingly
         assertEquals(EnumRobotVictoryState.WINNER, (myProxyRobots.robotsMap.
-                        get(ProtobufTest.REGISTERED_ROUTING_ID)).getVictoryState()
+                get(ProtobufTest.REGISTERED_ROUTING_ID)).getVictoryState()
         );
     }
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/config/ConfigurationEv3Test.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/config/ConfigurationEv3Test.java
@@ -73,4 +73,16 @@ public class ConfigurationEv3Test {
             fail(e.getMessage());
         }
     }
+
+    @Test
+    public void testGetHostname() {
+        final ConfigTank configTank;
+        try {
+            configTank = (ConfigTank) new ConfigurationResource(CONF_WIFI_RESOURCE_PATH).getConfigModel().getConfigRobots()
+                    .getConfigRobot("BananaWifiOne");
+            assertEquals("R2D2", configTank.getHostname());
+        } catch (final Exception e) {
+            fail(e.getMessage());
+        }
+    }
 }

--- a/proxy-robots-module/src/test/java/orwell/proxy/config/ConfigurationEv3Test.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/config/ConfigurationEv3Test.java
@@ -1,0 +1,76 @@
+package orwell.proxy.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import orwell.proxy.config.elements.ConfigNetworkInterface;
+import orwell.proxy.config.elements.ConfigTank;
+import orwell.proxy.config.source.ConfigurationResource;
+import orwell.proxy.robot.EnumModel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by Michaël Ludmann on 23/06/16.
+ */
+
+@RunWith(JUnit4.class)
+public class ConfigurationEv3Test {
+
+    private static final String CONF_WIFI_RESOURCE_PATH = "/configurationEv3Test.xml";
+
+    @Test
+    public void testGetTankEnumModelEv3() {
+        final ConfigTank configTank;
+        try {
+            configTank = (ConfigTank) new ConfigurationResource(CONF_WIFI_RESOURCE_PATH).getConfigModel().getConfigRobots()
+                    .getConfigRobot("BananaWifiOne");
+            assertEquals(EnumModel.EV3, configTank.getEnumModel());
+        } catch (final Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetConfigNetworkInterfaces() {
+        final ConfigTank configTank;
+        try {
+            configTank = (ConfigTank) new ConfigurationResource(CONF_WIFI_RESOURCE_PATH).getConfigModel().getConfigRobots()
+                    .getConfigRobot("BananaWifiOne");
+            assertEquals(2, configTank.getConfigNetworkInterfaces().size());
+        } catch (final Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetWlan0Elements() {
+        final ConfigTank configTank;
+        final ConfigNetworkInterface configNetworkInterfaceWlan0;
+        try {
+            configTank = (ConfigTank) new ConfigurationResource(CONF_WIFI_RESOURCE_PATH).getConfigModel().getConfigRobots()
+                    .getConfigRobot("BananaWifiOne");
+            configNetworkInterfaceWlan0 = configTank.getConfigNetworkInterface("wlan0");
+            assertEquals("192.168.2.219", configNetworkInterfaceWlan0.getIpAddress());
+            assertEquals("74:DA:38:7F:89:61", configNetworkInterfaceWlan0.getMacAddress());
+        } catch (final Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetWBr0Elements() {
+        final ConfigTank configTank;
+        final ConfigNetworkInterface configNetworkInterfaceBr0;
+        try {
+            configTank = (ConfigTank) new ConfigurationResource(CONF_WIFI_RESOURCE_PATH).getConfigModel().getConfigRobots()
+                    .getConfigRobot("BananaWifiOne");
+            configNetworkInterfaceBr0 = configTank.getConfigNetworkInterface("br0");
+            assertEquals("10.0.1.1", configNetworkInterfaceBr0.getIpAddress());
+            assertEquals("02:16:53:42:C3:AA", configNetworkInterfaceBr0.getMacAddress());
+        } catch (final Exception e) {
+            fail(e.getMessage());
+        }
+    }
+}

--- a/proxy-robots-module/src/test/java/orwell/proxy/config/ConfigurationEv3Test.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/config/ConfigurationEv3Test.java
@@ -3,6 +3,7 @@ package orwell.proxy.config;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import orwell.proxy.config.elements.ConfigMessaging;
 import orwell.proxy.config.elements.ConfigNetworkInterface;
 import orwell.proxy.config.elements.ConfigTank;
 import orwell.proxy.config.source.ConfigurationResource;
@@ -81,6 +82,21 @@ public class ConfigurationEv3Test {
             configTank = (ConfigTank) new ConfigurationResource(CONF_WIFI_RESOURCE_PATH).getConfigModel().getConfigRobots()
                     .getConfigRobot("BananaWifiOne");
             assertEquals("R2D2", configTank.getHostname());
+        } catch (final Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetConfigMessaging() {
+        final ConfigTank configTank;
+        final ConfigMessaging configMessaging;
+        try {
+            configTank = (ConfigTank) new ConfigurationResource(CONF_WIFI_RESOURCE_PATH).getConfigModel().getConfigRobots()
+                    .getConfigRobot("BananaWifiOne");
+            configMessaging = configTank.getConfigMessaging();
+            assertEquals(10001, configMessaging.getPullPort());
+            assertEquals(10000, configMessaging.getPushPort());
         } catch (final Exception e) {
             fail(e.getMessage());
         }

--- a/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
@@ -1,6 +1,6 @@
 package orwell.proxy.mock;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.IUnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.robot.*;
@@ -25,8 +25,14 @@ public class MockedTank extends IRobot {
         this.robotActions = new IRobotInput[]{new InputMove(), new InputFire()};
     }
 
+    @Override
     public void setRfidValue(final String rfidValue) {
         ((RfidSensor) robotElements[0]).setValue(rfidValue);
+    }
+
+    @Override
+    public void setColourValue(String colourValue) {
+        ((RfidSensor) robotElements[1]).setValue(colourValue);
     }
 
     public InputMove getInputMove() {
@@ -38,7 +44,7 @@ public class MockedTank extends IRobot {
     }
 
     @Override
-    public void sendUnitMessage(final UnitMessage unitMessage) {
+    public void sendUnitMessage(final IUnitMessage unitMessage) {
 
     }
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
@@ -44,8 +44,8 @@ public class MockedTank extends IRobot {
     }
 
     @Override
-    public void sendUnitMessage(final IUnitMessage unitMessage) {
-
+    public void sendUnitMessage(final IUnitMessage unitMessage) throws MessageNotSentException {
+        throw new MessageNotSentException("MockedTank");
     }
 
     @Override
@@ -70,7 +70,7 @@ public class MockedTank extends IRobot {
     }
 
     @Override
-    public void accept(final IRobotInputVisitor visitor) {
+    public void accept(final IRobotInputVisitor visitor) throws MessageNotSentException {
         for (final IRobotInput action : robotActions) {
             action.accept(visitor);
         }

--- a/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
@@ -1,6 +1,6 @@
 package orwell.proxy.mock;
 
-import lejos.mf.common.IUnitMessage;
+import lejos.mf.common.UnitMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.robot.*;
@@ -46,7 +46,7 @@ public class MockedTank extends IRobot {
     }
 
     @Override
-    public void sendUnitMessage(final IUnitMessage unitMessage) throws MessageNotSentException {
+    public void sendUnitMessage(final UnitMessage unitMessage) throws MessageNotSentException {
         if (!isAbleToSendUnitMessage()) {
             throw new MessageNotSentException("MockedTank");
         }

--- a/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/mock/MockedTank.java
@@ -13,6 +13,7 @@ public class MockedTank extends IRobot {
 
     private final IRobotElement[] robotElements;
     private final IRobotInput[] robotActions;
+    private boolean isAbleToSendUnitMessage;
 
     public MockedTank() {
         this.setRoutingId("tempRoutingId");
@@ -23,6 +24,7 @@ public class MockedTank extends IRobot {
         this.setTeamName("BLUE");
         this.robotElements = new IRobotElement[]{new RfidSensor(), new ColourSensor()};
         this.robotActions = new IRobotInput[]{new InputMove(), new InputFire()};
+        isAbleToSendUnitMessage = true;
     }
 
     @Override
@@ -45,7 +47,13 @@ public class MockedTank extends IRobot {
 
     @Override
     public void sendUnitMessage(final IUnitMessage unitMessage) throws MessageNotSentException {
-        throw new MessageNotSentException("MockedTank");
+        if (!isAbleToSendUnitMessage()) {
+            throw new MessageNotSentException("MockedTank");
+        }
+    }
+
+    private boolean isAbleToSendUnitMessage() {
+        return isAbleToSendUnitMessage;
     }
 
     @Override
@@ -81,5 +89,9 @@ public class MockedTank extends IRobot {
     public String toString() {
         return "MockedTank { [RoutingID] " + getRoutingId() +
                 " [TeamName] " + getTeamName() + " }";
+    }
+
+    public void makeUnableToSendUnitMessages(){
+        isAbleToSendUnitMessage = false;
     }
 }

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/EnumModelTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/EnumModelTest.java
@@ -1,0 +1,35 @@
+package orwell.proxy.robot;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Michaël Ludmann on 26/06/16.
+ */
+public class EnumModelTest {
+    @Test
+    public void getModelFromStringEv3LowerCase() throws Exception {
+        assertEquals(EnumModel.EV3, EnumModel.getModelFromString("ev3"));
+    }
+
+    @Test
+    public void getModelFromStringEv3UpperCase() throws Exception {
+        assertEquals(EnumModel.EV3, EnumModel.getModelFromString("EV3"));
+    }
+
+    @Test
+    public void getModelFromStringNxt() throws Exception {
+        assertEquals(EnumModel.NXT, EnumModel.getModelFromString("nxt"));
+    }
+
+    @Test
+    public void getModelFromRandomString() throws Exception {
+        assertEquals(EnumModel.NXT, EnumModel.getModelFromString("jambon"));
+    }
+
+    @Test
+    public void getModelFromNull() throws Exception {
+        assertEquals(EnumModel.NXT, EnumModel.getModelFromString(null));
+    }
+}

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.common.UnitMessageType;
 import org.easymock.Capture;
 import org.junit.After;
@@ -41,14 +41,14 @@ public class InputFireTest {
         inputFire.setFire(ProtobufTest.getTestInput().getFire());
 
         final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);
-        final Capture<UnitMessage> messageCapture = new Capture<>();
+        final Capture<StreamUnitMessage> messageCapture = new Capture<>();
         legoNxtTank.sendUnitMessage(capture(messageCapture));
         expectLastCall().once();
         replay(legoNxtTank);
 
         inputFire.sendUnitMessageTo(legoNxtTank);
         verify(legoNxtTank);
-        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMsgType());
+        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMessageType());
         assertEquals(INPUT_FIRE, messageCapture.getValue().getPayload());
     }
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
@@ -1,6 +1,7 @@
 package orwell.proxy.robot;
 
 import lejos.mf.common.StreamUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.UnitMessageType;
 import org.easymock.Capture;
 import org.junit.After;
@@ -42,7 +43,7 @@ public class InputFireTest {
         inputFire.setFire(ProtobufTest.getTestInput().getFire());
 
         final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);
-        final Capture<StreamUnitMessage> messageCapture = new Capture<>();
+        final Capture<UnitMessage> messageCapture = new Capture<>();
         legoNxtTank.sendUnitMessage(capture(messageCapture));
         expectLastCall().once();
         replay(legoNxtTank);

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
@@ -11,7 +11,6 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.ProtobufTest;
-import orwell.proxy.mock.MockedTank;
 
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
@@ -41,14 +40,14 @@ public class InputFireTest {
     public void testSendUnitMessageTo() throws Exception {
         inputFire.setFire(ProtobufTest.getTestInput().getFire());
 
-        final LegoTank legoTank = createNiceMock(LegoTank.class);
+        final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);
         final Capture<UnitMessage> messageCapture = new Capture<>();
-        legoTank.sendUnitMessage(capture(messageCapture));
+        legoNxtTank.sendUnitMessage(capture(messageCapture));
         expectLastCall().once();
-        replay(legoTank);
+        replay(legoNxtTank);
 
-        inputFire.sendUnitMessageTo(legoTank);
-        verify(legoTank);
+        inputFire.sendUnitMessageTo(legoNxtTank);
+        verify(legoNxtTank);
         assertEquals(UnitMessageType.Command, messageCapture.getValue().getMsgType());
         assertEquals(INPUT_FIRE, messageCapture.getValue().getPayload());
     }

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputFireTest.java
@@ -13,7 +13,8 @@ import org.slf4j.LoggerFactory;
 import orwell.proxy.ProtobufTest;
 
 import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Michaël Ludmann on 6/11/15.
@@ -37,7 +38,7 @@ public class InputFireTest {
     }
 
     @Test
-    public void testSendUnitMessageTo() throws Exception {
+    public void testSendUnitMessageTo() throws MessageNotSentException {
         inputFire.setFire(ProtobufTest.getTestInput().getFire());
 
         final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.common.UnitMessageType;
 import org.easymock.Capture;
 import org.junit.After;
@@ -42,14 +42,14 @@ public class InputMoveTest {
         inputMove.setMove(ProtobufTest.getTestInput().getMove());
 
         final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);
-        final Capture<UnitMessage> messageCapture = new Capture<>();
+        final Capture<StreamUnitMessage> messageCapture = new Capture<>();
         legoNxtTank.sendUnitMessage(capture(messageCapture));
         expectLastCall().once();
         replay(legoNxtTank);
 
         inputMove.sendUnitMessageTo(legoNxtTank);
         verify(legoNxtTank);
-        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMsgType());
+        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMessageType());
         assertEquals(INPUT_MOVE, messageCapture.getValue().getPayload());
     }
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
@@ -38,7 +38,7 @@ public class InputMoveTest {
     }
 
     @Test
-    public void testSendUnitMessageTo() throws Exception {
+    public void testSendUnitMessageTo() throws MessageNotSentException {
         inputMove.setMove(ProtobufTest.getTestInput().getMove());
 
         final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
@@ -1,6 +1,7 @@
 package orwell.proxy.robot;
 
 import lejos.mf.common.StreamUnitMessage;
+import lejos.mf.common.UnitMessage;
 import lejos.mf.common.UnitMessageType;
 import org.easymock.Capture;
 import org.junit.After;
@@ -42,7 +43,7 @@ public class InputMoveTest {
         inputMove.setMove(ProtobufTest.getTestInput().getMove());
 
         final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);
-        final Capture<StreamUnitMessage> messageCapture = new Capture<>();
+        final Capture<UnitMessage> messageCapture = new Capture<>();
         legoNxtTank.sendUnitMessage(capture(messageCapture));
         expectLastCall().once();
         replay(legoNxtTank);

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/InputMoveTest.java
@@ -41,14 +41,14 @@ public class InputMoveTest {
     public void testSendUnitMessageTo() throws Exception {
         inputMove.setMove(ProtobufTest.getTestInput().getMove());
 
-        final LegoTank legoTank = createNiceMock(LegoTank.class);
+        final LegoNxtTank legoNxtTank = createNiceMock(LegoNxtTank.class);
         final Capture<UnitMessage> messageCapture = new Capture<>();
-        legoTank.sendUnitMessage(capture(messageCapture));
+        legoNxtTank.sendUnitMessage(capture(messageCapture));
         expectLastCall().once();
-        replay(legoTank);
+        replay(legoNxtTank);
 
-        inputMove.sendUnitMessageTo(legoTank);
-        verify(legoTank);
+        inputMove.sendUnitMessageTo(legoNxtTank);
+        verify(legoNxtTank);
         assertEquals(UnitMessageType.Command, messageCapture.getValue().getMsgType());
         assertEquals(INPUT_MOVE, messageCapture.getValue().getPayload());
     }

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoEv3TankTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoEv3TankTest.java
@@ -1,14 +1,25 @@
 package orwell.proxy.robot;
 
+import lejos.mf.common.UnitMessage;
+import lejos.mf.common.UnitMessageType;
+import org.easymock.Capture;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import orwell.proxy.zmq.RobotMessageBroker;
 
+import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertEquals;
 
 /**
  * Created by Michaël Ludmann on 03/07/16.
  */
 public class LegoEv3TankTest {
+    private final static Logger logback = LoggerFactory.getLogger(LegoEv3TankTest.class);
+
+    private static final String RFID_VALUE = "12345678";
+    private final static String INPUT_MOVE = "move 50.5 10.0";
     private final String IP_ADDRESS = "192.168.0.17";
     private final String MAC_ADDRESS = "00:11:22:AA:BB";
     private final int VIDEO_STREAM_PORT = 1111;
@@ -16,6 +27,8 @@ public class LegoEv3TankTest {
     private final int PUSH_PORT = 10000;
     private final int PULL_PORT = 10001;
     private final String HOSTNAME = "HOSTNAME_TEST";
+    private final Capture<UnitMessage> messageCapture = new Capture<>();
+    private final UnitMessage unitMessageMove = new UnitMessage(UnitMessageType.Command, INPUT_MOVE);
     private LegoEv3Tank tank;
 
     @Before
@@ -26,9 +39,77 @@ public class LegoEv3TankTest {
                 PUSH_PORT, PULL_PORT, HOSTNAME);
     }
 
+    private LegoEv3Tank legoEv3TankFromMB(final RobotMessageBroker messageBroker) {
+        return new LegoEv3Tank(IP_ADDRESS, MAC_ADDRESS,
+                VIDEO_STREAM_PORT, IMAGE,
+                HOSTNAME, messageBroker);
+    }
+
     @Test
-    public void getCamera() {
+    public void testGetCamera() {
         assertEquals("nc:" + IP_ADDRESS + ":" + VIDEO_STREAM_PORT, tank.getCameraUrl());
     }
+
+    @Test
+    public void testSendUnitMessage() {
+        tank.setRfidValue(RFID_VALUE);
+        RobotMessageBroker messageBroker = createNiceMock(RobotMessageBroker.class);
+        expect(messageBroker.send(capture(messageCapture))).andReturn(true);
+        replay(messageBroker);
+
+        tank = legoEv3TankFromMB(messageBroker);
+
+        try {
+            tank.sendUnitMessage(unitMessageMove);
+        } catch (MessageNotSentException e) {
+            logback.error(e.getMessage());
+        }
+
+        verify(messageBroker);
+        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMessageType());
+        assertEquals(INPUT_MOVE, messageCapture.getValue().getPayload());
+    }
+
+    @Test
+    public void testConnect_succeeds() {
+        RobotMessageBroker messageBroker = createNiceMock(RobotMessageBroker.class);
+        messageBroker.bind();
+        expectLastCall().once();
+        replay(messageBroker);
+
+        tank = legoEv3TankFromMB(messageBroker);
+
+        assertEquals(EnumConnectionState.NOT_CONNECTED, tank.getConnectionState());
+        tank.connect(); // Trying to connect, this does not mean it is connected right away
+        assertEquals(EnumConnectionState.NOT_CONNECTED, tank.getConnectionState());
+
+        // We need to wait for the messageBroker to tell the robot it received a Connection message
+        tank.receivedNewMessage(new UnitMessage(UnitMessageType.Connection, "connected"));
+        assertEquals(EnumConnectionState.CONNECTED, tank.getConnectionState());
+    }
+
+    @Test
+    public void testCloseConnection() {
+        RobotMessageBroker messageBroker = createNiceMock(RobotMessageBroker.class);
+        messageBroker.close();
+        expectLastCall().once();
+        replay(messageBroker);
+
+        tank = legoEv3TankFromMB(messageBroker);
+
+        assertEquals(EnumConnectionState.NOT_CONNECTED, tank.getConnectionState());
+        tank.connect(); // Trying to connect, this does not mean it is connected right away
+        assertEquals(EnumConnectionState.NOT_CONNECTED, tank.getConnectionState());
+
+        // We need to wait for the messageBroker to tell the robot it received a Connection message
+        tank.receivedNewMessage(new UnitMessage(UnitMessageType.Connection, "connected"));
+        assertEquals(EnumConnectionState.CONNECTED, tank.getConnectionState());
+
+        tank.closeConnection();
+        // Check that the message broker close() method was called
+        verify(messageBroker);
+        assertEquals(EnumConnectionState.NOT_CONNECTED, tank.getConnectionState());
+    }
+
 
 }

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoEv3TankTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoEv3TankTest.java
@@ -1,0 +1,34 @@
+package orwell.proxy.robot;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Michaël Ludmann on 03/07/16.
+ */
+public class LegoEv3TankTest {
+    private final String IP_ADDRESS = "192.168.0.17";
+    private final String MAC_ADDRESS = "00:11:22:AA:BB";
+    private final int VIDEO_STREAM_PORT = 1111;
+    private final String IMAGE = "YELLOW HULL";
+    private final int PUSH_PORT = 10000;
+    private final int PULL_PORT = 10001;
+    private final String HOSTNAME = "HOSTNAME_TEST";
+    private LegoEv3Tank tank;
+
+    @Before
+    public void setUp() {
+        // Instantiate default tank
+        tank = new LegoEv3Tank(IP_ADDRESS, MAC_ADDRESS,
+                VIDEO_STREAM_PORT, IMAGE,
+                PUSH_PORT, PULL_PORT, HOSTNAME);
+    }
+
+    @Test
+    public void getCamera() {
+        assertEquals("nc:" + IP_ADDRESS + ":" + VIDEO_STREAM_PORT, tank.getCameraUrl());
+    }
+
+}

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
@@ -67,7 +67,11 @@ public class LegoNxtTankTest {
 
         tank = legoTankFromMF(messageFramework);
 
-        tank.sendUnitMessage(streamUnitMessageMove);
+        try {
+            tank.sendUnitMessage(streamUnitMessageMove);
+        } catch (MessageNotSentException e) {
+            e.printStackTrace();
+        }
         verify(messageFramework);
         assertEquals(UnitMessageType.Command, messageCapture.getValue().getMessageType());
         assertEquals(INPUT_MOVE, messageCapture.getValue().getPayload());
@@ -150,7 +154,7 @@ public class LegoNxtTankTest {
     }
 
     @Test
-    public void testAccept_inputVisitor_mock() {
+    public void testAccept_inputVisitor_mock() throws MessageNotSentException {
         // Simple test with mock visitor
         final RobotInputSetVisitor inputVisitor = createNiceMock(RobotInputSetVisitor.class);
 
@@ -172,7 +176,7 @@ public class LegoNxtTankTest {
     }
 
     @Test
-    public void testAccept_inputVisitor_concrete() {
+    public void testAccept_inputVisitor_concrete() throws MessageNotSentException {
         // Setup the LEGO BT message framework mock and instantiate the tank
         messageFramework = createNiceMock(MessageFramework.class);
         messageFramework.SendMessage(capture(messageCapture));

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
@@ -1,6 +1,6 @@
 package orwell.proxy.robot;
 
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import lejos.mf.common.UnitMessageType;
 import lejos.mf.pc.MessageFramework;
 import lejos.pc.comm.NXTInfo;
@@ -29,10 +29,10 @@ public class LegoNxtTankTest {
     private final static String RFID_VALUE = "11111111";
     private final static String COLOUR_VALUE = "2";
     private final static String INPUT_MOVE = "move 50.5 10.0";
-    private final Capture<UnitMessage> messageCapture = new Capture<>();
-    private final UnitMessage unitMessageRfid = new UnitMessage(UnitMessageType.Rfid, RFID_VALUE);
-    private final UnitMessage unitMessageColour = new UnitMessage(UnitMessageType.Colour, COLOUR_VALUE);
-    private final UnitMessage unitMessageMove = new UnitMessage(UnitMessageType.Command, INPUT_MOVE);
+    private final Capture<StreamUnitMessage> messageCapture = new Capture<>();
+    private final StreamUnitMessage streamUnitMessageRfid = new StreamUnitMessage(UnitMessageType.Rfid, RFID_VALUE);
+    private final StreamUnitMessage streamUnitMessageColour = new StreamUnitMessage(UnitMessageType.Colour, COLOUR_VALUE);
+    private final StreamUnitMessage streamUnitMessageMove = new StreamUnitMessage(UnitMessageType.Command, INPUT_MOVE);
 
     @TestSubject
     private LegoNxtTank tank;
@@ -67,9 +67,9 @@ public class LegoNxtTankTest {
 
         tank = legoTankFromMF(messageFramework);
 
-        tank.sendUnitMessage(unitMessageMove);
+        tank.sendUnitMessage(streamUnitMessageMove);
         verify(messageFramework);
-        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMsgType());
+        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMessageType());
         assertEquals(INPUT_MOVE, messageCapture.getValue().getPayload());
     }
 
@@ -131,7 +131,7 @@ public class LegoNxtTankTest {
      * 3. Tank reads a Color value: third read of ServerRobotState is not null
      */
     public void testReceivedNewMessage() {
-        tank.receivedNewMessage(unitMessageRfid);
+        tank.receivedNewMessage(streamUnitMessageRfid);
 
         final RobotElementStateVisitor stateVisitor = new RobotElementStateVisitor();
         tank.accept(stateVisitor);
@@ -142,7 +142,7 @@ public class LegoNxtTankTest {
         tank.accept(stateVisitor);
         assertNull(stateVisitor.getServerRobotStateBytes());
 
-        tank.receivedNewMessage(unitMessageColour);
+        tank.receivedNewMessage(streamUnitMessageColour);
 
         stateVisitor.clearServerRobotState();
         tank.accept(stateVisitor);
@@ -186,7 +186,7 @@ public class LegoNxtTankTest {
         final RobotInputSetVisitor inputSetVisitor = new RobotInputSetVisitor(ProtobufTest.getTestInput().toByteArray());
         tank.accept(inputSetVisitor);
         verify(messageFramework);
-        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMsgType());
+        assertEquals(UnitMessageType.Command, messageCapture.getValue().getMessageType());
         assertEquals(INPUT_MOVE, messageCapture.getValue().getPayload());
     }
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
@@ -70,7 +70,7 @@ public class LegoNxtTankTest {
         try {
             tank.sendUnitMessage(streamUnitMessageMove);
         } catch (MessageNotSentException e) {
-            e.printStackTrace();
+            logback.error(e.getMessage());
         }
         verify(messageFramework);
         assertEquals(UnitMessageType.Command, messageCapture.getValue().getMessageType());
@@ -126,6 +126,7 @@ public class LegoNxtTankTest {
         tank.closeConnection();
         // Check that the LEGO BT message framework close() method was called
         verify(messageFramework);
+        assertEquals(EnumConnectionState.NOT_CONNECTED, tank.getConnectionState());
     }
 
     @Test

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/LegoNxtTankTest.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.*;
  * Created by Michaël Ludmann on 11/04/15.
  */
 @RunWith(JUnit4.class)
-public class LegoTankTest {
-    private final static Logger logback = LoggerFactory.getLogger(LegoTankTest.class);
+public class LegoNxtTankTest {
+    private final static Logger logback = LoggerFactory.getLogger(LegoNxtTankTest.class);
     private final static String RFID_VALUE = "11111111";
     private final static String COLOUR_VALUE = "2";
     private final static String INPUT_MOVE = "move 50.5 10.0";
@@ -35,7 +35,7 @@ public class LegoTankTest {
     private final UnitMessage unitMessageMove = new UnitMessage(UnitMessageType.Command, INPUT_MOVE);
 
     @TestSubject
-    private LegoTank tank;
+    private LegoNxtTank tank;
 
     @Mock
     private MessageFramework messageFramework;
@@ -44,16 +44,16 @@ public class LegoTankTest {
     public void setUp() {
         logback.debug(">>>>>>>>> IN");
         // Instantiate default tank
-        tank = new LegoTank("", "", new MockedCamera(), "");
+        tank = new LegoNxtTank("", "", new MockedCamera(), "");
     }
 
-    private LegoTank legoTankFromMF(final MessageFramework messageFramework) {
-        return new LegoTank("BTNameTest", "BT-IDTest", messageFramework, new MockedCamera(), "ImageTest");
+    private LegoNxtTank legoTankFromMF(final MessageFramework messageFramework) {
+        return new LegoNxtTank("BTNameTest", "BT-IDTest", messageFramework, new MockedCamera(), "ImageTest");
     }
 
     @Test
     public void testToString() {
-        final String tankString = "LegoTank { [BTName]  [BT-ID]  [RoutingID] " + tank.getRoutingId() + " [TeamName]  }";
+        final String tankString = "LegoNxtTank { [BTName]  [BT-ID]  [RoutingID] " + tank.getRoutingId() + " [TeamName]  }";
         assertEquals(tankString, tank.toString());
     }
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotElementStateVisitorTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotElementStateVisitorTest.java
@@ -23,7 +23,7 @@ public class RobotElementStateVisitorTest {
     private final static Logger logback = LoggerFactory.getLogger(RobotElementStateVisitorTest.class);
 
     @Mock
-    private final LegoTank tank = new LegoTank("", "", new MockedCamera(), "");
+    private final LegoNxtTank tank = new LegoNxtTank("", "", new MockedCamera(), "");
 
     @TestSubject
     private RobotElementStateVisitor stateVisitor;

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
@@ -99,6 +99,20 @@ public class RobotFactoryTest {
     }
 
     @Test
+    public void getRobotLegoEv3Tank_BadNetworkAddr() throws ConfigRobotException {
+        final ConfigNetworkInterface cni = new ConfigNetworkInterface();
+        cni.setNetworkAddress("");
+
+        final ConfigTank configTank = new ConfigTank();
+        configTank.setConfigNetworkInterfaces(Arrays.asList(cni));
+        configTank.setModel("ev3");
+
+        final IRobot robot = robotFactory.getRobot(configTank);
+
+        assertNull(robot);
+    }
+
+    @Test
     public void getRobotLegoNxtTank() throws ConfigRobotException {
         final ConfigTank configTank = new ConfigTank();
         configTank.setModel(MODEL_NXT_TEST);

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
@@ -7,10 +7,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import orwell.proxy.config.elements.ConfigCamera;
-import orwell.proxy.config.elements.ConfigNetworkInterface;
-import orwell.proxy.config.elements.ConfigRobotException;
-import orwell.proxy.config.elements.ConfigTank;
+import orwell.proxy.config.elements.*;
 
 import java.util.Arrays;
 
@@ -83,13 +80,17 @@ public class RobotFactoryTest {
         cni.setIpAddress(IP_TEST);
         cni.setMacAddress(MAC_TEST);
 
-        // idem for camera of tank
         final ConfigCamera configCamera = new ConfigCamera();
         configCamera.setPort(PORT_TEST);
+
+        final ConfigMessaging configMessaging = new ConfigMessaging();
+        configMessaging.setPullPort(PORT_TEST);
+        configMessaging.setPushPort(PORT_TEST);
 
         final ConfigTank configTank = new ConfigTank();
         configTank.setConfigNetworkInterfaces(Arrays.asList(cni));
         configTank.setConfigCamera(configCamera);
+        configTank.setConfigMessaging(configMessaging);
         configTank.setModel(MODEL_EV3_TEST);
         configTank.setImage(IMAGE_TEST);
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
@@ -8,8 +8,11 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.config.elements.ConfigCamera;
+import orwell.proxy.config.elements.ConfigNetworkInterface;
 import orwell.proxy.config.elements.ConfigRobotException;
 import orwell.proxy.config.elements.ConfigTank;
+
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -29,6 +32,8 @@ public class RobotFactoryTest {
     private static final String MODEL_EV3_TEST = "ev3";
     private static final String MODEL_NXT_TEST = "nxt";
     private static final int PORT_TEST = 777;
+    private static final String NETWORK_ADDR_TEST = "wlan0";
+    private static final String MAC_TEST = "00:11:22:AA:BB";
     private RobotFactory robotFactory;
 
     @Before
@@ -73,8 +78,20 @@ public class RobotFactoryTest {
 
     @Test
     public void getRobotLegoEv3Tank() throws ConfigRobotException {
+        final ConfigNetworkInterface cni = new ConfigNetworkInterface();
+        cni.setNetworkAddress(NETWORK_ADDR_TEST);
+        cni.setIpAddress(IP_TEST);
+        cni.setMacAddress(MAC_TEST);
+
+        // idem for camera of tank
+        final ConfigCamera configCamera = new ConfigCamera();
+        configCamera.setPort(PORT_TEST);
+
         final ConfigTank configTank = new ConfigTank();
+        configTank.setConfigNetworkInterfaces(Arrays.asList(cni));
+        configTank.setCamera(configCamera);
         configTank.setModel(MODEL_EV3_TEST);
+        configTank.setImage(IMAGE_TEST);
 
         final IRobot robot = robotFactory.getRobot(configTank);
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
@@ -8,6 +8,7 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import orwell.proxy.config.elements.ConfigCamera;
+import orwell.proxy.config.elements.ConfigRobotException;
 import orwell.proxy.config.elements.ConfigTank;
 
 import static org.junit.Assert.assertEquals;
@@ -25,6 +26,8 @@ public class RobotFactoryTest {
     private static final String IMAGE_TEST = "ImageTest";
     private static final String TEMP_ROUTING_ID_TEST = "TempRoutingIdTest";
     private static final String IP_TEST = "IpTest";
+    private static final String MODEL_EV3_TEST = "ev3";
+    private static final String MODEL_NXT_TEST = "nxt";
     private static final int PORT_TEST = 777;
     private RobotFactory robotFactory;
 
@@ -36,14 +39,14 @@ public class RobotFactoryTest {
 
     @Test
     public void testGetLegoTank_NullConfigCamera() throws Exception {
-        final LegoTank legoTank = (LegoTank) robotFactory.getRobot(new ConfigTank());
-        assertEquals(IPWebcam.getDummy().getUrl(), legoTank.getCameraUrl());
+        final LegoNxtTank legoNxtTank = (LegoNxtTank) robotFactory.getRobot(new ConfigTank());
+        assertEquals(IPWebcam.getDummy().getUrl(), legoNxtTank.getCameraUrl());
     }
 
     @Test
     public void testGetLegoTank_NullParameter() throws Exception {
-        final LegoTank legoTank = (LegoTank) robotFactory.getRobot(null);
-        assertNull(legoTank);
+        final LegoNxtTank legoNxtTank = (LegoNxtTank) robotFactory.getRobot(null);
+        assertNull(legoNxtTank);
     }
 
     @Test
@@ -63,9 +66,29 @@ public class RobotFactoryTest {
         configTank.setCamera(configCamera);
 
         // Build a tank from the config
-        final LegoTank legoTank = (LegoTank) robotFactory.getRobot(configTank);
-        assertEquals(IMAGE_TEST, legoTank.getImage());
-        assertEquals("http://" + IP_TEST + ":" + PORT_TEST, legoTank.getCameraUrl());
+        final LegoNxtTank legoNxtTank = (LegoNxtTank) robotFactory.getRobot(configTank);
+        assertEquals(IMAGE_TEST, legoNxtTank.getImage());
+        assertEquals("http://" + IP_TEST + ":" + PORT_TEST, legoNxtTank.getCameraUrl());
+    }
+
+    @Test
+    public void getRobotLegoEv3Tank() throws ConfigRobotException {
+        final ConfigTank configTank = new ConfigTank();
+        configTank.setModel(MODEL_EV3_TEST);
+
+        final IRobot robot = robotFactory.getRobot(configTank);
+
+        assertEquals(LegoEv3Tank.class, robot.getClass());
+    }
+
+    @Test
+    public void getRobotLegoNxtTank() throws ConfigRobotException {
+        final ConfigTank configTank = new ConfigTank();
+        configTank.setModel(MODEL_NXT_TEST);
+
+        final IRobot robot = robotFactory.getRobot(configTank);
+
+        assertEquals(LegoNxtTank.class, robot.getClass());
     }
 
     @After

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotFactoryTest.java
@@ -68,7 +68,7 @@ public class RobotFactoryTest {
         final ConfigCamera configCamera = new ConfigCamera();
         configCamera.setIp(IP_TEST);
         configCamera.setPort(PORT_TEST);
-        configTank.setCamera(configCamera);
+        configTank.setConfigCamera(configCamera);
 
         // Build a tank from the config
         final LegoNxtTank legoNxtTank = (LegoNxtTank) robotFactory.getRobot(configTank);
@@ -89,7 +89,7 @@ public class RobotFactoryTest {
 
         final ConfigTank configTank = new ConfigTank();
         configTank.setConfigNetworkInterfaces(Arrays.asList(cni));
-        configTank.setCamera(configCamera);
+        configTank.setConfigCamera(configCamera);
         configTank.setModel(MODEL_EV3_TEST);
         configTank.setImage(IMAGE_TEST);
 
@@ -105,7 +105,7 @@ public class RobotFactoryTest {
 
         final ConfigTank configTank = new ConfigTank();
         configTank.setConfigNetworkInterfaces(Arrays.asList(cni));
-        configTank.setModel("ev3");
+        configTank.setModel(MODEL_EV3_TEST);
 
         final IRobot robot = robotFactory.getRobot(configTank);
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotInputSetVisitorTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotInputSetVisitorTest.java
@@ -29,7 +29,7 @@ public class RobotInputSetVisitorTest {
     private RobotInputSetVisitor inputSetVisitor;
 
     @Mock
-    private LegoTank tank;
+    private LegoNxtTank tank;
 
 
     @Before
@@ -62,7 +62,7 @@ public class RobotInputSetVisitorTest {
     @Test
     public void testVisit_Robot_Empty() {
         // Mock the tank
-        tank = createMock(LegoTank.class);
+        tank = createMock(LegoNxtTank.class);
         tank.sendUnitMessage(anyObject(UnitMessage.class));
         // We should not send any unitMessage (or we throw an exception)
         expectLastCall().andThrow(new AssertionFailedError("Tank should not send an unitMessage")).anyTimes();
@@ -84,7 +84,7 @@ public class RobotInputSetVisitorTest {
         inputSetVisitor.visit(inputFire);
 
         // Mock the tank
-        tank = createMock(LegoTank.class);
+        tank = createMock(LegoNxtTank.class);
         tank.sendUnitMessage(anyObject(UnitMessage.class));
         expectLastCall().times(2); // we should send two unitMessages
         replay(tank);

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotInputSetVisitorTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotInputSetVisitorTest.java
@@ -1,7 +1,7 @@
 package orwell.proxy.robot;
 
 import junit.framework.AssertionFailedError;
-import lejos.mf.common.UnitMessage;
+import lejos.mf.common.StreamUnitMessage;
 import org.easymock.Mock;
 import org.easymock.TestSubject;
 import org.junit.After;
@@ -63,7 +63,7 @@ public class RobotInputSetVisitorTest {
     public void testVisit_Robot_Empty() {
         // Mock the tank
         tank = createMock(LegoNxtTank.class);
-        tank.sendUnitMessage(anyObject(UnitMessage.class));
+        tank.sendUnitMessage(anyObject(StreamUnitMessage.class));
         // We should not send any unitMessage (or we throw an exception)
         expectLastCall().andThrow(new AssertionFailedError("Tank should not send an unitMessage")).anyTimes();
         replay(tank);
@@ -85,7 +85,7 @@ public class RobotInputSetVisitorTest {
 
         // Mock the tank
         tank = createMock(LegoNxtTank.class);
-        tank.sendUnitMessage(anyObject(UnitMessage.class));
+        tank.sendUnitMessage(anyObject(StreamUnitMessage.class));
         expectLastCall().times(2); // we should send two unitMessages
         replay(tank);
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotInputSetVisitorTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/robot/RobotInputSetVisitorTest.java
@@ -60,10 +60,14 @@ public class RobotInputSetVisitorTest {
 
 
     @Test
-    public void testVisit_Robot_Empty() {
+    public void testVisit_Robot_Empty() throws MessageNotSentException {
         // Mock the tank
         tank = createMock(LegoNxtTank.class);
-        tank.sendUnitMessage(anyObject(StreamUnitMessage.class));
+        try {
+            tank.sendUnitMessage(anyObject(StreamUnitMessage.class));
+        } catch (MessageNotSentException e) {
+            e.printStackTrace();
+        }
         // We should not send any unitMessage (or we throw an exception)
         expectLastCall().andThrow(new AssertionFailedError("Tank should not send an unitMessage")).anyTimes();
         replay(tank);
@@ -76,7 +80,7 @@ public class RobotInputSetVisitorTest {
 
 
     @Test
-    public void testVisit_Robot_Full() {
+    public void testVisit_Robot_Full() throws MessageNotSentException {
         // Setup the class
         final InputMove inputMove = new InputMove();
         inputSetVisitor.visit(inputMove);
@@ -85,7 +89,11 @@ public class RobotInputSetVisitorTest {
 
         // Mock the tank
         tank = createMock(LegoNxtTank.class);
-        tank.sendUnitMessage(anyObject(StreamUnitMessage.class));
+        try {
+            tank.sendUnitMessage(anyObject(StreamUnitMessage.class));
+        } catch (MessageNotSentException e) {
+            e.printStackTrace();
+        }
         expectLastCall().times(2); // we should send two unitMessages
         replay(tank);
 

--- a/proxy-robots-module/src/test/java/orwell/proxy/zmq/DebugTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/zmq/DebugTest.java
@@ -1,7 +1,0 @@
-package orwell.proxy.zmq;
-
-/**
- * Created by Michaël Ludmann on 31/08/16.
- */
-public class DebugTest {
-}

--- a/proxy-robots-module/src/test/java/orwell/proxy/zmq/DebugTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/zmq/DebugTest.java
@@ -1,0 +1,7 @@
+package orwell.proxy.zmq;
+
+/**
+ * Created by Michaël Ludmann on 31/08/16.
+ */
+public class DebugTest {
+}

--- a/proxy-robots-module/src/test/java/orwell/proxy/zmq/GameServerMessageBrokerTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/zmq/GameServerMessageBrokerTest.java
@@ -23,7 +23,7 @@ import static org.powermock.api.easymock.PowerMock.expectLastCall;
 import static org.powermock.api.easymock.PowerMock.replay;
 
 /**
- * Tests for {@link ZmqMessageBroker}.
+ * Tests for {@link GameServerMessageBroker}.
  * <p/>
  * Created by Michael Ludmann on 15/03/15.
  */
@@ -31,12 +31,12 @@ import static org.powermock.api.easymock.PowerMock.replay;
 @SuppressWarnings("unused")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ZMQ.Socket.class)
-public class ZmqMessageBrokerTest {
+public class GameServerMessageBrokerTest {
 
     static final String TEST_ROUTING_ID_1 = "testRoutingId_1";
     static final String TEST_ROUTING_ID_2 = "testRoutingId_2";
     static final long OUTGOING_MSG_PERIOD_HIGH = 50000;
-    private final static Logger logback = LoggerFactory.getLogger(ZmqMessageBrokerTest.class);
+    private final static Logger logback = LoggerFactory.getLogger(GameServerMessageBrokerTest.class);
     private final static long MAX_TIMEOUT_MS = 500;
     private final static String PUSH_ADDRESS = "tcp://127.0.0.1:9000";
     private final static String SUB_ADDRESS = "tcp://127.0.0.1:9001";
@@ -44,14 +44,14 @@ public class ZmqMessageBrokerTest {
     private final FrequencyFilter frequencyFilter = new FrequencyFilter(OUTGOING_MSG_PERIOD_HIGH);
 
     @TestSubject
-    private ZmqMessageBroker zmf;
+    private GameServerMessageBroker zmf;
 
     @Before
     public void setUp() {
         logback.debug(">>>>>>>>> IN");
         final ArrayList<IFilter> filters = new ArrayList<>();
         filters.add(frequencyFilter);
-        zmf = new ZmqMessageBroker(100000, 1000, 1000, filters);
+        zmf = new GameServerMessageBroker(100000, 1000, 1000, filters);
     }
 
     public void initZmqMocks() {
@@ -74,9 +74,9 @@ public class ZmqMessageBrokerTest {
         replay(mockedZmqContext);
 
         try {
-            MemberModifier.field(ZmqMessageBroker.class, "context").set(zmf, mockedZmqContext);
-            MemberModifier.field(ZmqMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
-            MemberModifier.field(ZmqMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
+            MemberModifier.field(GameServerMessageBroker.class, "context").set(zmf, mockedZmqContext);
+            MemberModifier.field(GameServerMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
+            MemberModifier.field(GameServerMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
         } catch (final IllegalAccessException e) {
             logback.error(e.getMessage());
         }
@@ -197,9 +197,9 @@ public class ZmqMessageBrokerTest {
         replay(mockedZmqContext);
 
         try {
-            MemberModifier.field(ZmqMessageBroker.class, "context").set(zmf, mockedZmqContext);
-            MemberModifier.field(ZmqMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
-            MemberModifier.field(ZmqMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
+            MemberModifier.field(GameServerMessageBroker.class, "context").set(zmf, mockedZmqContext);
+            MemberModifier.field(GameServerMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
+            MemberModifier.field(GameServerMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
         } catch (final IllegalAccessException e) {
             logback.error(e.getMessage());
         }

--- a/proxy-robots-module/src/test/java/orwell/proxy/zmq/ServerGameMessageBrokerTest.java
+++ b/proxy-robots-module/src/test/java/orwell/proxy/zmq/ServerGameMessageBrokerTest.java
@@ -23,7 +23,7 @@ import static org.powermock.api.easymock.PowerMock.expectLastCall;
 import static org.powermock.api.easymock.PowerMock.replay;
 
 /**
- * Tests for {@link GameServerMessageBroker}.
+ * Tests for {@link ServerGameMessageBroker}.
  * <p/>
  * Created by Michael Ludmann on 15/03/15.
  */
@@ -31,12 +31,12 @@ import static org.powermock.api.easymock.PowerMock.replay;
 @SuppressWarnings("unused")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ZMQ.Socket.class)
-public class GameServerMessageBrokerTest {
+public class ServerGameMessageBrokerTest {
 
     static final String TEST_ROUTING_ID_1 = "testRoutingId_1";
     static final String TEST_ROUTING_ID_2 = "testRoutingId_2";
     static final long OUTGOING_MSG_PERIOD_HIGH = 50000;
-    private final static Logger logback = LoggerFactory.getLogger(GameServerMessageBrokerTest.class);
+    private final static Logger logback = LoggerFactory.getLogger(ServerGameMessageBrokerTest.class);
     private final static long MAX_TIMEOUT_MS = 500;
     private final static String PUSH_ADDRESS = "tcp://127.0.0.1:9000";
     private final static String SUB_ADDRESS = "tcp://127.0.0.1:9001";
@@ -44,14 +44,14 @@ public class GameServerMessageBrokerTest {
     private final FrequencyFilter frequencyFilter = new FrequencyFilter(OUTGOING_MSG_PERIOD_HIGH);
 
     @TestSubject
-    private GameServerMessageBroker zmf;
+    private ServerGameMessageBroker zmf;
 
     @Before
     public void setUp() {
         logback.debug(">>>>>>>>> IN");
         final ArrayList<IFilter> filters = new ArrayList<>();
         filters.add(frequencyFilter);
-        zmf = new GameServerMessageBroker(100000, 1000, 1000, filters);
+        zmf = new ServerGameMessageBroker(100000, 1000, 1000, filters);
     }
 
     public void initZmqMocks() {
@@ -74,9 +74,9 @@ public class GameServerMessageBrokerTest {
         replay(mockedZmqContext);
 
         try {
-            MemberModifier.field(GameServerMessageBroker.class, "context").set(zmf, mockedZmqContext);
-            MemberModifier.field(GameServerMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
-            MemberModifier.field(GameServerMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
+            MemberModifier.field(ServerGameMessageBroker.class, "context").set(zmf, mockedZmqContext);
+            MemberModifier.field(ServerGameMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
+            MemberModifier.field(ServerGameMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
         } catch (final IllegalAccessException e) {
             logback.error(e.getMessage());
         }
@@ -197,9 +197,9 @@ public class GameServerMessageBrokerTest {
         replay(mockedZmqContext);
 
         try {
-            MemberModifier.field(GameServerMessageBroker.class, "context").set(zmf, mockedZmqContext);
-            MemberModifier.field(GameServerMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
-            MemberModifier.field(GameServerMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
+            MemberModifier.field(ServerGameMessageBroker.class, "context").set(zmf, mockedZmqContext);
+            MemberModifier.field(ServerGameMessageBroker.class, "sender").set(zmf, mockedZmqSocketSend);
+            MemberModifier.field(ServerGameMessageBroker.class, "receiver").set(zmf, mockedZmqSocketRecv);
         } catch (final IllegalAccessException e) {
             logback.error(e.getMessage());
         }

--- a/proxy-robots-module/src/test/resources/configurationEv3Test.xml
+++ b/proxy-robots-module/src/test/resources/configurationEv3Test.xml
@@ -31,6 +31,10 @@
             <camera>
                 <port>9100</port>
             </camera>
+            <messaging>
+                <pushPort>10000</pushPort>
+                <pullPort>10001</pullPort>
+            </messaging>
             <image>Yellow hull -- TO BE BETTER CONFIGURED</image>
         </tank>
     </robots>

--- a/proxy-robots-module/src/test/resources/configurationEv3Test.xml
+++ b/proxy-robots-module/src/test/resources/configurationEv3Test.xml
@@ -28,14 +28,8 @@
                 <ip>10.0.1.1</ip>
             </networkInterface>
             <hostname>R2D2</hostname>
-
-
-            <bluetoothName>Daneel</bluetoothName>
-            <bluetoothID>001653119482</bluetoothID>
             <camera>
-                <ip>192.168.1.50</ip>
                 <port>9100</port>
-                <resourcePath>/videofeed</resourcePath>
             </camera>
             <image>Yellow hull -- TO BE BETTER CONFIGURED</image>
         </tank>

--- a/proxy-robots-module/src/test/resources/configurationEv3Test.xml
+++ b/proxy-robots-module/src/test/resources/configurationEv3Test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding='utf-8'?>
+<setup>
+    <proxy>
+        <udpBroadcast>
+            <port>9080</port>
+            <attempts>5</attempts>
+            <timeoutPerAttemptMs>1000</timeoutPerAttemptMs>
+        </udpBroadcast>
+        <receiveTimeout>300000</receiveTimeout>
+        <senderLinger>1000</senderLinger>
+        <receiverLinger>1000</receiverLinger>
+        <outgoingMsgPeriod>500</outgoingMsgPeriod>
+        <server-game name='irondamien'>
+            <ip>192.168.1.37</ip>
+            <pushPort>9000</pushPort>
+            <subPort>9001</subPort>
+        </server-game>
+    </proxy>
+
+    <robots>
+        <tank tempRoutingID='BananaWifiOne' shouldRegister='1' model='ev3'>
+            <networkInterface addr='wlan0'>
+                <mac>74:DA:38:7F:89:61</mac>
+                <ip>192.168.2.219</ip>
+            </networkInterface>
+            <networkInterface addr='br0'>
+                <mac>02:16:53:42:C3:AA</mac>
+                <ip>10.0.1.1</ip>
+            </networkInterface>
+            <hostname>R2D2</hostname>
+
+
+            <bluetoothName>Daneel</bluetoothName>
+            <bluetoothID>001653119482</bluetoothID>
+            <camera>
+                <ip>192.168.1.50</ip>
+                <port>9100</port>
+                <resourcePath>/videofeed</resourcePath>
+            </camera>
+            <image>Yellow hull -- TO BE BETTER CONFIGURED</image>
+        </tank>
+    </robots>
+</setup>


### PR DESCRIPTION
Add support of EV3 bricks on the proxy. They should be connected by WiFi. This uses zmq as the messaging layer.

Add a direct controller basic GUI for simple integration test to communicate with a EV3 directly.